### PR TITLE
Add colors to SCSS variables file

### DIFF
--- a/dwellingly/src/scss/variables.scss
+++ b/dwellingly/src/scss/variables.scss
@@ -1,1 +1,11 @@
-$testColor: #bada55;
+// colors
+$brandBlue: #053d6f;
+$gray: #8e8e93;
+$darkGray: #555555;
+$lightGray: #d1d1d1;
+$lighterGray: #eeeeee;
+$blue: #51a3fc;
+$orange: #fdbc49;
+$red: #fc575a;
+
+$gradient: linear-gradient(to bottom, #6f90fc 0%,#52baed 100%);


### PR DESCRIPTION
Went through the PDF with xScope and pulled out all of the distinct colors I could find, as well as the gradient that appears in the header and login page. Just winged it on the variable names!

// colors
$brandBlue: #053d6f;
$gray: #8e8e93;
$darkGray: #555555;
$lightGray: #d1d1d1;
$lighterGray: #eeeeee;
$blue: #51a3fc;
$orange: #fdbc49;
$red: #fc575a;

$gradient: linear-gradient(to bottom, #6f90fc 0%,#52baed 100%);
