### PR TITLE
Add apiurl env variable

### DIFF
--- a/dwellingly/.env
+++ b/dwellingly/.env
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://localhost:5000

--- a/dwellingly/.gitignore
+++ b/dwellingly/.gitignore
@@ -205,10 +205,6 @@ typings/
 # Yarn Integrity file
 .yarn-integrity
 
-# dotenv environment variables file
-.env
-.env.test
-
 # parcel-bundler cache (https://parceljs.org/)
 
 # next.js build output

--- a/dwellingly/src/Auth.js
+++ b/dwellingly/src/Auth.js
@@ -6,7 +6,7 @@ import { UserContext } from './App';
 export const auth = {
   isAuthenticated: false,
   async authenticate(username, password) {
-    return axios.post('http://localhost:5000/login', {
+    return axios.post(`${process.env.REACT_APP_API_URL}/login`, {
       username: username,
       password: password
     })


### PR DESCRIPTION
Running locally should work as normal but when we go live, this should pull in the correct live API Url
(The variable was already added to the prod heroku app settings)