### PR TITLE
Integrate tenants to dashboard

### DIFF
--- a/src/components/Collapsible/collapsible.scss
+++ b/src/components/Collapsible/collapsible.scss
@@ -7,6 +7,10 @@
   margin-bottom: 5px;
   &.isCollapsed {
       max-height: 35px;
+      .fa-chevron-down {
+          transform: rotate(-90deg);
+          transition: transform 100ms;
+      }
   }
   &__header {
     padding: 5px;
@@ -22,10 +26,13 @@
   &__header_title,
   &__toggle {
     font-weight: bold;
-  }
-  &__toggle {
     border: 0;
     background-color: transparent;
+    cursor: pointer;
+  }
+  &__toggle.isDisabled {
+    color: $gray;
+    cursor: default;
   }
   &__row {
     border-bottom: 1px solid $lighterGray;
@@ -61,5 +68,9 @@
         margin-left: 0;
       }
     }
+  }
+  .fa-chevron-down {
+    transform: rotate(0);
+    transition: transform 100ms;
   }
 }

--- a/src/components/Collapsible/collapsible.scss
+++ b/src/components/Collapsible/collapsible.scss
@@ -9,8 +9,14 @@
       max-height: 35px;
       .fa-chevron-down {
           transform: rotate(-90deg);
-          transition: transform 100ms;
       }
+  }
+  &.isDisabled {
+    .collapsible__header_title, 
+    .collapsible__toggle {
+      color: $gray;
+      cursor: default;
+    }
   }
   &__header {
     padding: 5px;
@@ -20,19 +26,18 @@
     justify-content: space-between;
     margin-bottom: 0.75rem; //bc Bulma and negative margins
   }
-  &__header_title {
-    text-transform: uppercase;
-  }
   &__header_title,
   &__toggle {
     font-weight: bold;
     border: 0;
     background-color: transparent;
+  }
+  &__header_title {
+    text-transform: uppercase;
     cursor: pointer;
   }
-  &__toggle.isDisabled {
-    color: $gray;
-    cursor: default;
+  &__toggle {
+    cursor: pointer;
   }
   &__row {
     border-bottom: 1px solid $lighterGray;
@@ -71,6 +76,6 @@
   }
   .fa-chevron-down {
     transform: rotate(0);
-    transition: transform 100ms;
+    transition: transform 250ms;
   }
 }

--- a/src/components/Collapsible/index.js
+++ b/src/components/Collapsible/index.js
@@ -4,19 +4,19 @@ import './collapsible.scss';
 function Collapsible(props) {
     const { children, title, count } = props;
     const countAsNumber = +(count || 0);
-    const [isCollapsed, setIsCollapsed] = useState(countAsNumber <= 0);
+    const [isCollapsed, setIsCollapsed] = useState(false);
     const toggleCollapsed = () => {
-        setIsCollapsed(countAsNumber ? !isCollapsed : true);
+        setIsCollapsed(countAsNumber ? !isCollapsed : false);
     }
 
     return (
-        <div className={`collapsible ${isCollapsed && 'isCollapsed'}`}>
+        <div className={`collapsible ${isCollapsed && 'isCollapsed'} ${!countAsNumber && 'isDisabled'}`}>
             <div className="collapsible__header">
-                <h3 className="collapsible__header_title">{title}
-                <span className="count"> ({countAsNumber})</span>
+                <h3 className="collapsible__header_title" onClick={toggleCollapsed}>
+                    {title}<span className="count"> ({countAsNumber})</span>
                 </h3>
                 <button 
-                    className={`collapsible__toggle ${countAsNumber && 'isDisabled'}`}
+                    className='collapsible__toggle'
                     onClick={toggleCollapsed}
                 >
                     <span className="icon">

--- a/src/components/Collapsible/index.js
+++ b/src/components/Collapsible/index.js
@@ -2,23 +2,32 @@ import React, {useState} from 'react';
 import './collapsible.scss';
 
 function Collapsible(props) {
-    const { data, children, title, count } = props;
-
-    const [isCollapsed, setIsCollapsed] = useState(false);
+    const { children, title, count } = props;
+    const countAsNumber = +(count || 0);
+    const [isCollapsed, setIsCollapsed] = useState(countAsNumber <= 0);
+    const toggleCollapsed = () => {
+        setIsCollapsed(countAsNumber ? !isCollapsed : true);
+    }
 
     return (
         <div className={`collapsible ${isCollapsed && 'isCollapsed'}`}>
             <div className="collapsible__header">
                 <h3 className="collapsible__header_title">{title}
-                {count && <span className="count"> ({count})</span>}
+                <span className="count"> ({countAsNumber})</span>
                 </h3>
-                <button href="#" className="collapsible__toggle" onClick={()=>{ setIsCollapsed(!isCollapsed)}}>
+                <button 
+                    className={`collapsible__toggle ${countAsNumber && 'isDisabled'}`}
+                    onClick={toggleCollapsed}
+                >
                     <span className="icon">
                         <i className="fas fa-chevron-down"></i>
                     </span>
                 </button>
             </div>
-            {props.children}
+            {countAsNumber
+                ? children
+                : (<></>)
+            }
         </div>
     );
 };

--- a/src/components/NewStaffItem/index.js
+++ b/src/components/NewStaffItem/index.js
@@ -1,0 +1,28 @@
+import React from 'react';
+
+const NewStaffItem = ({ id, firstName, lastName, propertyName, staff, handleStaffAssignmentChange, staffList }) => (
+    <div className="collapsible__row columns">
+        <div className="collapsible__col column">{`${firstName} ${lastName}`}</div>
+        <div className="collapsible__col column">
+            {propertyName}<br />
+            <span className="subtext">Property Manager Name (fix this)</span>
+        </div>
+        <div className="dashboard__colapsible_col column">
+            <div className="select is-rounded">
+                <select
+                    onChange={e => handleStaffAssignmentChange(e, id)}
+                    value={staff || 'default'}
+                >
+                    <option value='default' disabled>Staff Name</option>
+                    {
+                        staffList.map(({ id, firstName, lastName }) => (
+                            <option key={id} value={id}>{`${firstName} ${lastName}`}</option>
+                        ))
+                    }
+                </select>
+            </div>
+        </div>
+    </div>
+);
+
+export default NewStaffItem;

--- a/src/utils/useMountEffect.js
+++ b/src/utils/useMountEffect.js
@@ -1,0 +1,3 @@
+import { useEffect } from 'react';
+const useMountEffect = fn => useEffect(fn, []);
+export default useMountEffect;

--- a/src/views/dashboard.js
+++ b/src/views/dashboard.js
@@ -80,11 +80,12 @@ export const Dashboard = (props) => {
                 { 'staffIDs': [staff] }, 
                 makeAuthHeaders(session)
             ));
+
         axios.all(tenantUpdateReqs)
             .then(axios.spread((...responses) => {
-                const updatedTenants = unstaffedTenants.filter(({ id }) => {
-                    const isTenantUpdated = responses.find(({ data }) => data.id === id);
-                    // using filter to keep all but this updated tenant, so negate the result
+                const updatedTenants = unstaffedTenants.filter(tenant => {
+                    const isTenantUpdated = responses.find(({ data }) => data.id === tenant.id);
+                    // using filter to keep non-updated tenants, so negate the result
                     return !isTenantUpdated;
                 });
                 setUnstaffedTenants(updatedTenants);

--- a/src/views/dashboard.js
+++ b/src/views/dashboard.js
@@ -154,6 +154,7 @@ export const Dashboard = (props) => {
                         </Collapsible>
                         <Collapsible
                             title="Request for Access"
+                            count={ACCESS_REQUEST_DATA.length}
                         >
                             {
                                 ACCESS_REQUEST_DATA.map((requestItemData, index) => {

--- a/src/views/dashboard.js
+++ b/src/views/dashboard.js
@@ -1,7 +1,8 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useContext } from 'react';
 import { useHistory } from 'react-router-dom';
 import axios from 'axios';
 import UserContext from '../UserContext';
+import useMountEffect from '../utils/useMountEffect';
 import { MODULE_DATA } from '../components/DashboardModule/data';
 import DashboardModule from '../components/DashboardModule';
 import Collapsible from '../components/Collapsible';
@@ -19,7 +20,7 @@ export const Dashboard = (props) => {
     const history = useHistory();  
     const userContext = useContext(UserContext);
 
-    useEffect(() => {
+    useMountEffect(() => {
         axios
             .get(`${process.env.REACT_APP_API_URL}/tenants`, makeAuthHeaders(userContext))
             .then(({ data }) => {
@@ -39,7 +40,7 @@ export const Dashboard = (props) => {
             .post(`${process.env.REACT_APP_API_URL}/users/role`, pendingUsersObj, makeAuthHeaders(userContext))
             .then(({ data }) => setUsersPending(data.users))
             .catch(error => alert(error));
-    }, [userContext]);
+    });
   
     const handleAddClick = (id) => {
         const path = '/request-access/' + id;

--- a/src/views/dashboard.js
+++ b/src/views/dashboard.js
@@ -24,14 +24,14 @@ export const Dashboard = (props) => {
             .get(`${process.env.REACT_APP_API_URL}/tenants`, makeAuthHeaders(userContext))
             .then(({ data }) => {
                 const unstaffed = data.tenants.filter(tenant => !tenant.staff);
-                setUnstaffedTenants(unstaffed);
-            })
-            .catch(error => alert(error));
+                if(! unstaffed.length) return;
 
-        const adminUsersObj = { "userrole": "admin" };
-        axios
-            .post(`${process.env.REACT_APP_API_URL}/users/role`, adminUsersObj, makeAuthHeaders(userContext))
-            .then(({ data }) => setStaffList(data.users))
+                setUnstaffedTenants(unstaffed);
+                const adminUsersObj = { "userrole": "admin" };
+                return axios
+                    .post(`${process.env.REACT_APP_API_URL}/users/role`, adminUsersObj, makeAuthHeaders(userContext))
+                    .then(({ data }) => setStaffList(data.users));
+            })
             .catch(error => alert(error));
 
         const pendingUsersObj = { "userrole": "pending" };

--- a/src/views/dashboard.js
+++ b/src/views/dashboard.js
@@ -23,7 +23,6 @@ export const Dashboard = (props) => {
           .then(({ data }) => {
               const unstaffed = data.tenants.filter(t => !t.staff);
               setUnstaffedTenants(unstaffed);
-              console.log(unstaffed);
           })
           .catch((error) => {
               alert(error);
@@ -71,6 +70,28 @@ export const Dashboard = (props) => {
             return tenant
         });
         setUnstaffedTenants(updatedTenants);
+    }
+
+    const handleStaffAssignment = () => {
+        const data = unstaffedTenants
+            .filter(({ staff }) => staff)
+            .map(({ id, staff }) => ({ id, data: { 'staffIDs': [staff] } }));
+        data.forEach(({ id, data }) => {
+            axios
+                .put(`${process.env.REACT_APP_API_URL}/tenants/${id}`, data, makeAuthHeaders(session))
+                .then(({ data }) => {
+                    const updatedTenants = unstaffedTenants.filter(({ id }) => {
+                        const isTenantUpdatedCorrectly = data.id === id && data.staff && data.staff.length;
+                        // using filter to keep all but this updated tenant, so negate the result
+                        return !isTenantUpdatedCorrectly;
+                    });
+                    setUnstaffedTenants(updatedTenants);
+                })
+                .catch((error) => {
+                    alert(error);
+                    console.log(error);
+                })
+        })
     }
 
     const staffOptions = staffList.map(({ id, firstName, lastName }) => (
@@ -122,7 +143,12 @@ export const Dashboard = (props) => {
                             <div className="dashboard__assignments_container">
                                 {unstaffedTenantItems}
                                 <div className="dashboard__assignments_button_container">
-                                    <button className={`${areStaffAssigned && 'active'} dashboard__save_assignments_button button is-rounded`}>SAVE ASSIGNMENTS</button>
+                                    <button 
+                                        className={`${areStaffAssigned && 'active'} dashboard__save_assignments_button button is-rounded`}
+                                        onClick={handleStaffAssignment}
+                                    >
+                                        SAVE ASSIGNMENTS
+                                    </button>
                                 </div>
                             </div>
                         </Collapsible>

--- a/src/views/dashboard.js
+++ b/src/views/dashboard.js
@@ -6,6 +6,7 @@ import { MODULE_DATA, ACCESS_REQUEST_DATA } from '../components/DashboardModule/
 import DashboardModule from '../components/DashboardModule';
 import Collapsible from '../components/Collapsible';
 import RequestItem from '../components/RequestItem';
+import NewStaffItem from '../components/NewStaffItem';
 
 const makeAuthHeaders = ({ user }) => ({ headers: { 'Authorization': `Bearer ${user.accessJwt}` } });
 
@@ -96,31 +97,6 @@ export const Dashboard = (props) => {
             });
     }
 
-    const staffOptions = staffList.map(({ id, firstName, lastName }) => (
-        <option key={id} value={id}>{`${firstName} ${lastName}`}</option>
-    ));
-
-    const unstaffedTenantItems = unstaffedTenants.map(({ id, firstName, lastName, propertyName, staff }) => (
-        <div key={id} className="collapsible__row columns">
-            <div className="collapsible__col column">{`${firstName} ${lastName}`}</div>
-            <div className="collapsible__col column">
-                {propertyName}<br />
-                <span className="subtext">Property Manager Name (fix this)</span>
-            </div>
-            <div className="dashboard__colapsible_col column">
-                <div className="select is-rounded">
-                    <select
-                        onChange={e => handleStaffAssignmentChange(e, id)}
-                        value={staff || 'default'}
-                    >
-                        <option value='default' disabled>Staff Name</option>
-                        {staffOptions}
-                    </select>
-                </div>
-            </div>
-        </div>
-    ));
-
     return (
         <>
             <div className="dashboard__container">
@@ -143,7 +119,11 @@ export const Dashboard = (props) => {
                             count={unstaffedTenants.length}
                         >
                             <div className="dashboard__assignments_container">
-                                {unstaffedTenantItems}
+                                {
+                                    unstaffedTenants.map(tenant => (
+                                        <NewStaffItem key={tenant.id} { ...tenant } handleStaffAssignmentChange={handleStaffAssignmentChange} staffList={staffList} />
+                                    ))
+                                }
                                 <div className="dashboard__assignments_button_container">
                                     <button 
                                         className={`${areStaffAssigned && 'active'} dashboard__save_assignments_button button is-rounded`}


### PR DESCRIPTION
addressing issue #174. 

**NOTE: this code will run only with the backend branch "tenants-routes" (or with the dev branch after the tenants-routes PR is merged)**

- [x] get a list of the tenants who have no staff assignments. GET from /tenants and those tenants without an assigned staff member will have `staff: None` in their JSON data
- [x] get a list of the JOIN staff members for assignment. POST to /users/role and include the following JSON object in the body: "userrole": "admin".
- [x] when the "Save Assignments" button is clicked, for each tenant whose staff assignment has been updated, send a PUT request to /tenants/<tenantID> and with a JSON body as follows: staffIDs: [<staffID from the staff members list>]
- [x] after the "Save Assignments" button is clicked, remove those tenants from the list who now have been given staff assignments
