### PR TITLE
Allow for frontend to be deployed on Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,8 @@
+{
+  "name": "dwellingly",
+  "buildpacks": [
+      {
+        "url": "https://buildpack-registry.s3.amazonaws.com/buildpacks/mars/create-react-app.tgz"
+      }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "dwellingly",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:5000",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.27",
     "@fortawesome/free-solid-svg-icons": "^5.12.1",

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -40,7 +40,7 @@ export const checkForStoredRefreshToken = () => {
 export const auth = {
   isAuthenticated: false,
   async authenticate(email, password) {
-    return axios.post("/login", {
+    return axios.post("/api/login", {
       email: email,
       password: password
     })
@@ -73,7 +73,7 @@ export const auth = {
       })
   },
   async refreshAccess(refreshToken) {
-    return axios.post("/refresh", {},
+    return axios.post("/api/refresh", {},
       { headers: {"Authorization" : `Bearer ${refreshToken}`} }
     )
       .then((response) => {

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -40,7 +40,7 @@ export const checkForStoredRefreshToken = () => {
 export const auth = {
   isAuthenticated: false,
   async authenticate(email, password) {
-    return axios.post(`${process.env.REACT_APP_API_URL}/login`, {
+    return axios.post("/login", {
       email: email,
       password: password
     })
@@ -73,7 +73,7 @@ export const auth = {
       })
   },
   async refreshAccess(refreshToken) {
-    return axios.post(`${process.env.REACT_APP_API_URL}/refresh`, {},
+    return axios.post("/refresh", {},
       { headers: {"Authorization" : `Bearer ${refreshToken}`} }
     )
       .then((response) => {

--- a/src/views/addProperty.js
+++ b/src/views/addProperty.js
@@ -24,7 +24,7 @@ const validationSchema = Yup.object().shape({
 });
 
 const formHandler = (data, context) => {
-    axios.post(`${process.env.REACT_APP_API_URL}/properties`, data, { headers: {"Authorization" : `Bearer ${context.user.accessJwt}`} })
+    axios.post("/properties", data, { headers: {"Authorization" : `Bearer ${context.user.accessJwt}`} })
         .then(function(response){
             alert("Property Added!");
         })

--- a/src/views/addProperty.js
+++ b/src/views/addProperty.js
@@ -24,7 +24,7 @@ const validationSchema = Yup.object().shape({
 });
 
 const formHandler = (data, context) => {
-    axios.post("/properties", data, { headers: {"Authorization" : `Bearer ${context.user.accessJwt}`} })
+    axios.post("/api/properties", data, { headers: {"Authorization" : `Bearer ${context.user.accessJwt}`} })
         .then(function(response){
             alert("Property Added!");
         })

--- a/src/views/dashboard.js
+++ b/src/views/dashboard.js
@@ -22,7 +22,7 @@ export const Dashboard = (props) => {
 
     useMountEffect(() => {
         axios
-            .get(`${process.env.REACT_APP_API_URL}/tenants`, makeAuthHeaders(userContext))
+            .get("/tenants", makeAuthHeaders(userContext))
             .then(({ data }) => {
                 const unstaffed = data.tenants.filter(tenant => !tenant.staff);
                 if(! unstaffed.length) return;
@@ -30,14 +30,14 @@ export const Dashboard = (props) => {
                 setUnstaffedTenants(unstaffed);
                 const adminUsersObj = { "userrole": "admin" };
                 return axios
-                    .post(`${process.env.REACT_APP_API_URL}/users/role`, adminUsersObj, makeAuthHeaders(userContext))
+                    .post("/users/role", adminUsersObj, makeAuthHeaders(userContext))
                     .then(({ data }) => setStaffList(data.users));
             })
             .catch(error => alert(error));
 
         const pendingUsersObj = { "userrole": "pending" };
         axios
-            .post(`${process.env.REACT_APP_API_URL}/users/role`, pendingUsersObj, makeAuthHeaders(userContext))
+            .post("/users/role", pendingUsersObj, makeAuthHeaders(userContext))
             .then(({ data }) => setUsersPending(data.users))
             .catch(error => alert(error));
     });
@@ -78,7 +78,7 @@ export const Dashboard = (props) => {
             .filter(({ staff }) => staff)
             .map(({ id, staff }) => axios
             .put(
-                `${process.env.REACT_APP_API_URL}/tenants/${id}`, 
+                "/tenants/${id}",
                 { 'staffIDs': [staff] }, 
                 makeAuthHeaders(userContext)
             ));

--- a/src/views/dashboard.js
+++ b/src/views/dashboard.js
@@ -22,7 +22,7 @@ export const Dashboard = (props) => {
 
     useMountEffect(() => {
         axios
-            .get("/tenants", makeAuthHeaders(userContext))
+            .get("/api/tenants", makeAuthHeaders(userContext))
             .then(({ data }) => {
                 const unstaffed = data.tenants.filter(tenant => !tenant.staff);
                 if(! unstaffed.length) return;
@@ -30,14 +30,14 @@ export const Dashboard = (props) => {
                 setUnstaffedTenants(unstaffed);
                 const adminUsersObj = { "userrole": "admin" };
                 return axios
-                    .post("/users/role", adminUsersObj, makeAuthHeaders(userContext))
+                    .post("/api/users/role", adminUsersObj, makeAuthHeaders(userContext))
                     .then(({ data }) => setStaffList(data.users));
             })
             .catch(error => alert(error));
 
         const pendingUsersObj = { "userrole": "pending" };
         axios
-            .post("/users/role", pendingUsersObj, makeAuthHeaders(userContext))
+            .post("/api/users/role", pendingUsersObj, makeAuthHeaders(userContext))
             .then(({ data }) => setUsersPending(data.users))
             .catch(error => alert(error));
     });
@@ -78,7 +78,7 @@ export const Dashboard = (props) => {
             .filter(({ staff }) => staff)
             .map(({ id, staff }) => axios
             .put(
-                "/tenants/${id}",
+                "/api/tenants/${id}",
                 { 'staffIDs': [staff] }, 
                 makeAuthHeaders(userContext)
             ));

--- a/src/views/properties.js
+++ b/src/views/properties.js
@@ -67,7 +67,7 @@ export class Properties extends Component {
     }
 
     getProperties = (context) => {
-        axios.get("/properties", { headers: {"Authorization" : `Bearer ${context.user.accessJwt}`} })
+        axios.get("/api/properties", { headers: {"Authorization" : `Bearer ${context.user.accessJwt}`} })
         .then((response) => {
             this.setState({properties: response.data.properties});
         })

--- a/src/views/properties.js
+++ b/src/views/properties.js
@@ -67,7 +67,7 @@ export class Properties extends Component {
     }
 
     getProperties = (context) => {
-        axios.get(`${process.env.REACT_APP_API_URL}/properties`, { headers: {"Authorization" : `Bearer ${context.user.accessJwt}`} })
+        axios.get("/properties", { headers: {"Authorization" : `Bearer ${context.user.accessJwt}`} })
         .then((response) => {
             this.setState({properties: response.data.properties});
         })

--- a/static.json
+++ b/static.json
@@ -1,0 +1,11 @@
+{
+  "root": "build/",
+  "routes": {
+    "/**": "index.html"
+  },
+  "proxies": {
+    "/api/": {
+      "origin": "${REACT_APP_API_URL}"
+    }
+  }
+}


### PR DESCRIPTION
See https://dwellinglypdx.herokuapp.com for an example.

This uses `--buildpack mars/create-react-app`.

Note that all endpoints are now prefixed under `/api/` to match the backend (see https://github.com/codeforpdx/dwellinglybackend/pull/37).