### PR TITLE
Integrate emergency numbers

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -148,6 +148,7 @@ export class App extends React.Component {
               <PrivateRoute exact path='/add/property' component={AddProperty}/>
               <PrivateRoute exact path='/add/manager' component={Dashboard} />
               <PrivateRoute exact path='/add/emergencycontact' component={AddEmergencyContact} />
+              <PrivateRoute exact path='/edit/emergencycontact/:id' component={AddEmergencyContact} />
               <PrivateRoute exact path='/manage/tenants' component={Dashboard} />
               <PrivateRoute exact path='/manage/properties' component={Properties} />
               <PrivateRoute exact path='/manage/managers' component={Dashboard} />

--- a/src/scss/pages/_addemergencycontact.scss
+++ b/src/scss/pages/_addemergencycontact.scss
@@ -4,6 +4,7 @@
         display: flex;
         flex-direction: column;
         padding: 45px;
+        position: relative;
     }
     
     &__main_container {
@@ -33,6 +34,17 @@
                 color: $blue;
             }
         }
+    }
+
+    &__loading {
+        position: absolute;
+        left: 0;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        text-align: center;
+        background-color: $lighterGray;
+        padding-top: 30%;
     }
 }
 

--- a/src/scss/pages/_emergencyContacts.scss
+++ b/src/scss/pages/_emergencyContacts.scss
@@ -59,11 +59,19 @@
                 flex-grow: 1;
                 margin-left: -.1rem;
                 font-weight: bold;
+
+                &.active {
+                    color: $blue;
+                    cursor: pointer;
+                }
             }
             &__contact_column {
                 text-align: right;
                 padding-right: 4.5rem;
                 font-weight: bold;
+                .number-container {
+                    display: inline-block;
+                }
             }
             &__contact_action {
                 overflow: hidden;

--- a/src/views/addEmergencyContact.js
+++ b/src/views/addEmergencyContact.js
@@ -110,7 +110,7 @@ const AddEmergencyContact = (props) => {
         
         setEditMode(true);
         axios
-            .get(`${process.env.REACT_APP_API_URL}/emergencycontacts/${id}`, makeAuthHeaders(userContext))
+            .get(`/api/emergencycontacts/${id}`, makeAuthHeaders(userContext))
             .then(({ data }) => {
                 setContactValues(data);
                 setInitialized(true);
@@ -119,8 +119,8 @@ const AddEmergencyContact = (props) => {
     });
 
     const formHandler = data => {
-        const startPost = () => axios.post(`${process.env.REACT_APP_API_URL}/emergencycontacts`, data, makeAuthHeaders(userContext));
-        const startPut = () => axios.put(`${process.env.REACT_APP_API_URL}/emergencycontacts/${data.id}`, data, makeAuthHeaders(userContext));
+        const startPost = () => axios.post(`/api/emergencycontacts`, data, makeAuthHeaders(userContext));
+        const startPut = () => axios.put(`/api/emergencycontacts/${data.id}`, data, makeAuthHeaders(userContext));
         const axiosReq = () => editMode ? startPut() : startPost();            
 
         axiosReq()

--- a/src/views/addEmergencyContact.js
+++ b/src/views/addEmergencyContact.js
@@ -1,6 +1,12 @@
-import React from 'react';
+import React, { useContext, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import axios from 'axios';
+import UserContext from '../UserContext';
 import { Form, Field, Formik, FieldArray } from 'formik';
 import * as Yup from 'yup';
+import useMountEffect from '../utils/useMountEffect';
+
+const makeAuthHeaders = ({ user }) => ({ headers: { 'Authorization': `Bearer ${user.accessJwt}` } });
 
 const validationSchema = Yup.object().shape({
     name: Yup.string()
@@ -9,7 +15,7 @@ const validationSchema = Yup.object().shape({
         .required("*Name is required"),
     description: Yup.string()
         .max(256, "*Description can't be longer than 256 characters"),
-    numbers: Yup.array().of(
+    contact_numbers: Yup.array().of(
         Yup.object().shape({
             number: Yup.string()
                 .min(5, "*Number must contain at least 5 digits to be a valid phone/text number")
@@ -24,11 +30,6 @@ const validationSchema = Yup.object().shape({
     )
 });
 
-const formHandler = data => {
-    console.log('submission data:');
-    console.log(data);
-}
-
 const FieldError = ({ error }) => {
     if(!error) return null;
     return (
@@ -39,41 +40,41 @@ const FieldError = ({ error }) => {
 };
 
 const NumberSubForm = ({ i, values, errors, handleChange }) => { 
-    const subFormErrors = errors.numbers && errors.numbers[i] ? errors.numbers[i] : null;
+    const subFormErrors = errors.contact_numbers && errors.contact_numbers[i] ? errors.contact_numbers[i] : null;
     return (
         <>
             <div className="form-row columns">
-                <label className="column is-one-quarter" htmlFor={`numbers[${i}].number`}>Phone Number</label>
+                <label className="column is-one-quarter" htmlFor={`contact_numbers[${i}].number`}>Phone Number</label>
                 <Field
                     className="column form-field"
                     type="text"
-                    name={`numbers[${i}].number`}
+                    name={`contact_numbers[${i}].number`}
                     onChange={handleChange}
-                    value={values.numbers[i].number}
+                    value={values.contact_numbers[i].number}
                     placeholder="Phone Number"
                 />
                 {subFormErrors && <FieldError error={subFormErrors.number} />}
             </div>
             <div className="form-row columns">
-                <label className="column is-one-quarter" htmlFor={`numbers[${i}].numtype`}>Phone Number Type</label>
+                <label className="column is-one-quarter" htmlFor={`contact_numbers[${i}].numtype`}>Phone Number Type</label>
                 <Field
                     className="column form-field"
                     type="text"
-                    name={`numbers[${i}].numtype`}
+                    name={`contact_numbers[${i}].numtype`}
                     onChange={handleChange}
-                    value={values.numbers[i].numtype}
+                    value={values.contact_numbers[i].numtype}
                     placeholder="Phone Number Type (Opional)"
                 />
                 {subFormErrors && <FieldError error={subFormErrors.numtype} />}
             </div>
             <div className="form-row columns">
-                <label className="column is-one-quarter" htmlFor={`numbers[${i}].extension`}>Extension</label>
+                <label className="column is-one-quarter" htmlFor={`contact_numbers[${i}].extension`}>Extension</label>
                 <Field
                     className="column form-field"
                     type="text"
-                    name={`numbers[${i}].extension`}
+                    name={`contact_numbers[${i}].extension`}
                     onChange={handleChange}
-                    value={values.numbers[i].extension}
+                    value={values.contact_numbers[i].extension}
                     placeholder="Extension (Optional)"
                 />
                 {subFormErrors && <FieldError error={subFormErrors.extension} />}
@@ -82,88 +83,132 @@ const NumberSubForm = ({ i, values, errors, handleChange }) => {
     );
 };
 
-const AddEmergencyContact = () => {
+const emptyContact = {
+    name: "",
+    description: "",
+    contact_numbers: [{
+        number: "",
+        numtype: "",
+        extension: ""
+    }],
+};
+
+const AddEmergencyContact = (props) => {
+    const history = useHistory();
+    const userContext = useContext(UserContext);
+    const [initialized, setInitialized] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const [editMode, setEditMode] = useState(false);
+    const [contactValues, setContactValues] = useState(emptyContact);
+
+    useMountEffect(() => {
+        const id = props.match.params.id;
+        if(!id && id !== 0) {
+            setInitialized(true);
+            return;
+        }
+        
+        setEditMode(true);
+        axios
+            .get(`${process.env.REACT_APP_API_URL}/emergencycontacts/${id}`, makeAuthHeaders(userContext))
+            .then(({ data }) => {
+                setContactValues(data);
+                setInitialized(true);
+            })
+            .catch(error => alert(error));
+    });
+
+    const formHandler = data => {
+        const startPost = () => axios.post(`${process.env.REACT_APP_API_URL}/emergencycontacts`, data, makeAuthHeaders(userContext));
+        const startPut = () => axios.put(`${process.env.REACT_APP_API_URL}/emergencycontacts/${data.id}`, data, makeAuthHeaders(userContext));
+        const axiosReq = () => editMode ? startPut() : startPost();            
+
+        axiosReq()
+            .then(() => {
+                history.push('/emergency');
+            })
+            .catch(error => alert(error));
+        setLoading(true);
+    }
+  
     return (
         <div className="add-emergency-contact__container">
-            <h2 className="page-title">Create Emergency Contact</h2>
-            <Formik
-                initialValues={{
-                    name: "",
-                    description: "",
-                    numbers: [{
-                        number: "",
-                        numtype: "",
-                        extension: ""
-                    }]
-                }}
-                validationSchema={validationSchema}
-                onSubmit={(values, { setSubmitting, resetForm }) => {
-                    console.log('submitting');
-                    setSubmitting(true);
-                    formHandler(values);
-                    resetForm();
-                    setSubmitting(false);
-                }}>
-                {({ handleSubmit, handleChange, values, errors, isValid, isSubmitting }) => (
-                    <div className="form-container add-emergency-contact__main_container">
-                        <Form className="add-emergency-contact__form-container" onSubmit={handleSubmit}>
-                            <div className="form-row columns">
-                                <label className="column is-one-quarter" htmlFor="name">Contact Name</label>
-                                <Field
-                                    className="column form-field"
-                                    type="text"
-                                    name="name"
-                                    onChange={handleChange}
-                                    value={values.name}
-                                    placeholder="Name or Organization"
-                                />
-                                <FieldError error={errors.name} />
-                            </div>
-                            <div className="form-row columns">
-                                <label className="column is-one-quarter" htmlFor="description">Organization Description</label>
-                                <Field
-                                    className="column form-field"
-                                    type="text"
-                                    name="description"
-                                    onChange={handleChange}
-                                    value={values.description}
-                                    placeholder="Description text (Optional)"
-                                    error={errors.description}
-                                />
-                                <FieldError error={errors.description} />
-                            </div>
-                            <FieldArray 
-                                name="numbers"
-                                render={numbersArrayFields => {
-                                    const addRowValid = (values.numbers[0].number !== "") && (!errors.numbers || !errors.numbers[values.numbers.length - 1].number);
-                                    const addRow = () => addRowValid && numbersArrayFields.push({ number: "", numtype: "", extension: "" });
+            <h2 className="page-title">{editMode ? 'Edit' : 'Create'} Emergency Contact</h2>
+            {loading &&
+                <div className='add-emergency-contact__loading'>Loading ...</div>
+            }
+            {initialized &&
+                <Formik
+                    initialValues={contactValues}
+                    validationSchema={validationSchema}
+                    onSubmit={(values, { setSubmitting, resetForm }) => {
+                        console.log('submitting');
+                        setSubmitting(true);
+                        formHandler(values);
+                        resetForm();
+                        setSubmitting(false);
+                    }}>
+                    {({ handleSubmit, handleChange, values, errors, isValid, isSubmitting }) => (
+                        <div className="form-container add-emergency-contact__main_container">
+                            <Form className="add-emergency-contact__form-container" onSubmit={handleSubmit}>
+                                <div className="form-row columns">
+                                    <label className="column is-one-quarter" htmlFor="name">Contact Name</label>
+                                    <Field
+                                        className="column form-field"
+                                        type="text"
+                                        name="name"
+                                        onChange={handleChange}
+                                        value={values.name}
+                                        placeholder="Name or Organization"
+                                    />
+                                    <FieldError error={errors.name} />
+                                </div>
+                                <div className="form-row columns">
+                                    <label className="column is-one-quarter" htmlFor="description">Organization Description</label>
+                                    <Field
+                                        className="column form-field"
+                                        type="text"
+                                        name="description"
+                                        onChange={handleChange}
+                                        value={values.description}
+                                        placeholder="Description text (Optional)"
+                                        error={errors.description}
+                                    />
+                                    <FieldError error={errors.description} />
+                                </div>
+                                <FieldArray 
+                                    name="contact_numbers"
+                                    render={numbersArrayFields => {
+                                        const addRowValid = (values.contact_numbers[0].number !== "") && (!errors.contact_numbers || !errors.contact_numbers[values.contact_numbers.length - 1].number);
+                                        const addRow = () => addRowValid && numbersArrayFields.push({ number: "", numtype: "", extension: "" });
                                     
-                                    return(
-                                        <>
-                                            {values.numbers.map((_, i) => (
-                                                <NumberSubForm key={i} i={i} values={values} errors={errors} handleChange={handleChange} />
-                                            ))}
-                                            <div className="form-add-rows-container">
-                                                <span className={`${addRowValid ? "active" : ""} is-rounded form-add-rows`} onClick={addRow}>
-                                                    <i className="fas fa-plus-circle"></i> Add New Phone Number
-                                                </span>
-                                            </div>
-                                        </>
-                                    );
-                                }}
-                            />
-                            <div className="container-footer">
-                                <button className={`${isValid && "active"} save_button button is-rounded`} type="submit" disabled={isSubmitting}>
-                                    ADD EMERGENCY NUMBER
-                                </button>
-                                <button className="button is-dark is-rounded" onClick={() => console.log("cancel pressed")} type="button">
-                                    CANCEL
-                                </button>
-                            </div>
-                        </Form>
-                    </div>
-                )}
-            </Formik>
+                                        return(
+                                            <>
+                                                {values.contact_numbers.map((_, i) => (
+                                                    <NumberSubForm key={i} i={i} values={values} errors={errors} handleChange={handleChange} />
+                                                ))}
+                                                <div className="form-add-rows-container">
+                                                    <span className={`${addRowValid ? "active" : ""} is-rounded form-add-rows`} onClick={addRow}>
+                                                        <i className="fas fa-plus-circle"></i> Add New Phone Number
+                                                    </span>
+                                                </div>
+                                            </>
+                                        );
+                                    }}
+                                />
+                                <div className="container-footer">
+                                    <button className={`${isValid && "active"} save_button button is-rounded`} type="submit" disabled={isSubmitting}>
+                                        {editMode ? 'UPDATE' : 'ADD'} EMERGENCY NUMBER
+                                    </button>
+                                    <button className="button is-dark is-rounded" onClick={() => history.push('/emergency')} type="button">
+                                        CANCEL
+                                    </button>
+                                </div>
+                            </Form>
+                        </div>
+                    )}
+                </Formik>
+            }
         </div>
     );
 }

--- a/src/views/emergencyContacts.js
+++ b/src/views/emergencyContacts.js
@@ -48,7 +48,7 @@ const EmergencyContacts = () => {
 
     useMountEffect(() => {
       axios
-          .get(`${process.env.REACT_APP_API_URL}/emergencycontacts`, makeAuthHeaders(userContext))
+          .get(`/api/emergencycontacts`, makeAuthHeaders(userContext))
           .then(({ data }) => {
               setApiContacts(data.emergency_contacts);
           })
@@ -63,7 +63,7 @@ const EmergencyContacts = () => {
         const continueDelete = window.confirm('Are you sure you want to delete the emergency contact?');
         if(!continueDelete) return;
         axios
-            .delete(`${process.env.REACT_APP_API_URL}/emergencycontacts/${id}`, makeAuthHeaders(userContext))
+            .delete(`/api/emergencycontacts/${id}`, makeAuthHeaders(userContext))
             .then(() => {
                 setApiContacts(apiContacts.filter(contact => contact.id !== id));
             })


### PR DESCRIPTION
Integrate emergency contacts list page and emergency contacts add/edit page with the API

**Note** this PR needs to be tested with the backend branch "emergency-contacts" (or with the development branch after [PR #39](https://github.com/codeforpdx/dwellinglybackend/pull/39) is closed)

- [x] GET /emergencycontacts and populate the emergency contacts list page
- [x] use POST /emergencycontacts to add a contact after the form submission is complete for "create new emergency contact"
- [x] use DELETE /emergencycontacts/<id> to remove a contact when edit mode is selected and the delete button (minus sign) is clicked. 
  - I added a confirmation dialog before the delete is finalized. This can easily be removed if it's not needed
- [x] add a link to edit a contact. This link brings up the edit emergency contact page (same as the add contact page - but with information pre-filled). Use PUT /emergencycontacts/<id> to update the contact information in the database
