### PR TITLE
Fixed tenant column on properties page to reflect total tenant count

### DIFF
--- a/src/views/properties.js
+++ b/src/views/properties.js
@@ -27,7 +27,7 @@ const columns = [{
       return { width: "20%" };
     }
   }, {
-    dataField: 'tenants',
+    dataField: 'totalTenants',
     text: 'Tenants',
     sort: true,
     headerStyle: () => {
@@ -82,7 +82,9 @@ export class Properties extends Component {
     getProperties = (context) => {
         axios.get("/api/properties", { headers: {"Authorization" : `Bearer ${context.user.accessJwt}`} })
         .then((response) => {
-            this.setState({properties: response.data.properties});
+            const { data : { properties } }  = response;
+            properties.forEach( property => property.totalTenants = property.tenantIDs.length )
+            this.setState({properties: properties});
         })
         .catch((error) => {
             alert(error);


### PR DESCRIPTION
### What issue is this solving?
Please connect this Pull Request to the issue it is resolving by using the controls on the right side of this PR.
Resolves codeforpdx/dwellingly-app#269


### Any helpful knowledge/context for the reviewer?
Is a `npm install` necessary?
Any special requirements to test?

In ./src/views/properties after line 87, add:
properties.forEach( property => {
    console.log(property.tenantIDs.length);
    console.log(property.totalTenants);
});

Navigate to properties page in localhost:3000 and confirm that the numbers in the console match.


### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
- [x] There aren't any unnecessary commits or files changed (shouldn't touch the /stashed folder unless the issue requests it)

If you're having trouble meeting this criteria, feel free to reach out on Slack for help!