### PR TITLE
Title And Pen re-usable component

### DIFF
--- a/Reusable_Components_Doc.md
+++ b/Reusable_Components_Doc.md
@@ -1,0 +1,24 @@
+## Reusable Components Documentation
+
+*If you make a component that might be reused in the future please document it here in the following format. Also thank you for making them!*
+
+### **Name**: ___ 
+* **File path**: ___
+* **Input/Props**: ___
+* **Currently in use**: ___
+* **Will be used in**: ___
+* **Additional info**: ___
+_____
+
+### **Name**: TitleAndPen
+* **File path**: "src/components/TitleAndPen"
+* **Input/Props**: {title, isEditing, setEditingStatus}
+* **Currently used in**: emergencyContacts, Manager
+* **Will be used in**: Tenants (figma pg 30), Properties (figma pg 49)
+* **Additional info**: While isEditing and setEditingStatus can be initiated in the parent scope with useState(), for convience they are in a hook that can be imported by name from the same file. (i.e <import TitleAndPen, { useEditingStatus } from '../components/TitleAndPen';>) \
+You would then call it like this: <const { isEditing, setEditingStatus } = useEditingStatus()>
+_____
+
+
+
+

--- a/contributors.md
+++ b/contributors.md
@@ -7,3 +7,4 @@ CodeforPDX:
 - Marie Ehrman
 - Max Hunter
 - Marcus Jensen
+- Scott Harlan

--- a/src/components/TitleAndPen/index.js
+++ b/src/components/TitleAndPen/index.js
@@ -1,0 +1,25 @@
+import React, { useState } from "react"
+
+import './titleAndPen.scss';
+
+export function useEditingStatus() {
+  const [isEditing, setEditingStatus] = useState(false)
+  return { isEditing, setEditingStatus }
+}
+
+export default function TitleAndPen({ manager, isEditing, setEditingStatus }) {
+  return (
+    <div className="title__container">
+      <h2>
+        {manager.firstName} {manager.lastName}
+      </h2>
+      <button
+        className={`rounded${isEditing ? "--is-editing" : ""}`}
+        onClick={() => setEditingStatus(prevBool => !prevBool)}
+        disabled={isEditing}
+      >
+        <i className="fas fa-pen icon"></i>
+      </button>
+    </div >
+  )
+}

--- a/src/components/TitleAndPen/index.js
+++ b/src/components/TitleAndPen/index.js
@@ -7,11 +7,11 @@ export function useEditingStatus() {
   return { isEditing, setEditingStatus }
 }
 
-export default function TitleAndPen({ manager, isEditing, setEditingStatus }) {
+export default function TitleAndPen({ title, isEditing, setEditingStatus }) {
   return (
     <div className="title__container">
       <h2>
-        {manager.firstName} {manager.lastName}
+        {title}
       </h2>
       <button
         className={`rounded${isEditing ? "--is-editing" : ""}`}

--- a/src/components/TitleAndPen/titleAndPen.scss
+++ b/src/components/TitleAndPen/titleAndPen.scss
@@ -1,0 +1,37 @@
+@import '../../scss/variables.scss';
+
+.title__container {
+  display: flex;
+  align-items: center;
+  h2 {
+    font-size: 22px;
+    color: $brandBlue;
+    font-weight: bold;
+  }
+  .rounded {
+    margin-left: 16px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 22px;
+    height: 22px;
+    border: $darkGray;
+    border-radius: 50%;
+    background-color: $darkGray;
+    cursor: pointer;
+    .icon {
+      font-size: 12px;
+      color: $white;
+    }
+  }
+  .rounded--is-editing {
+    @extend .rounded;
+    border: $blue;
+    background-color: $blue;
+    cursor: pointer;
+    .icon {
+      font-size: 12px;
+      color: $white;
+    }
+  }
+}

--- a/src/scss/pages/_emergencyContacts.scss
+++ b/src/scss/pages/_emergencyContacts.scss
@@ -3,32 +3,9 @@
         .section-header {
             display: flex;
             flex-direction: row;
+            justify-content: space-between;
             align-items: center;
             padding-bottom: 45px;
-
-            .page-title {
-                flex-grow: 1;
-                display: flex;
-                align-items: center;
-                h2 {
-                    font-weight: bold;
-                }
-                .rounded {
-                    margin-left: 1rem;
-                    display: flex;
-                    justify-content: center;
-                    align-items: center;
-                    width: 1em;
-                    height: 1em;
-                    border-radius: 50%;
-                    background-color: $darkGray;
-                    cursor: pointer;
-                    .icon {
-                        font-size: .5em;
-                        color: $white;
-                    }
-                }
-            }
         }
 
         .row_container {

--- a/src/scss/pages/_manager.scss
+++ b/src/scss/pages/_manager.scss
@@ -6,47 +6,6 @@
     min-height: 100vh;
     background-color: white;
     padding: 45px;
-    .title__container {
-      display: flex;
-      align-items: center;
-      h2 {
-        font-size: 22px;
-        color: $brandBlue;
-        font-weight: bold;
-      }
-      .rounded {
-        margin-left: 16px;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        width: 22px;
-        height: 22px;
-        border: $darkGray;
-        border-radius: 50%;
-        background-color: $darkGray;
-        cursor: pointer;
-        .icon {
-          font-size: 12px;
-          color: $white;
-        }
-      }
-      .rounded--is-editing {
-        margin-left: 16px;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        width: 22px;
-        height: 22px;
-        border: $lightGray;
-        border-radius: 50%;
-        background-color: $lightGray;
-        cursor: pointer;
-        .icon {
-          font-size: 12px;
-          color: $white;
-        }
-      }
-    }
     .manager__contact {
       position: relative;
       padding: 25px 0 25px 0;

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -10,6 +10,7 @@ $red: #fc575a;
 $darkGray: #555555;
 $lightGray: #d1d1d1;
 $lighterGray: #eeeeee;
+$white: #FFF;
 $breakpointMobile: 1200px;
 
 $gradient: linear-gradient(to bottom, #6f90fc 0%, #52baed 100%);

--- a/src/views/Manager/index.js
+++ b/src/views/Manager/index.js
@@ -104,7 +104,7 @@ const Manager = () => {
 
   return (
     <div className="manager__container">
-      <TitleAndPen manager={manager} isEditing={isEditing} setEditingStatus={setEditingStatus} />
+      <TitleAndPen title={`${manager.firstName} ${manager.lastName}`} isEditing={isEditing} setEditingStatus={setEditingStatus} />
       <div className="manager__contact">
         <h1 className="secondary-title">CONTACT</h1>
         <div className="contact-details">

--- a/src/views/Manager/index.js
+++ b/src/views/Manager/index.js
@@ -4,6 +4,7 @@ import * as Yup from "yup";
 import { useLocation } from "react-router-dom";
 import * as axios from "axios";
 import { PROPERTY_MANAGER_DATA } from "../dummyData/pManagerData";
+import TitleAndPen, { useEditingStatus } from "../../components/TitleAndPen";
 
 const validationSchema = Yup.object().shape({
   firstName: Yup.string()
@@ -34,7 +35,7 @@ const Manager = () => {
   );
 
   const [manager, setManager] = useState(dummyDataManagerInfo);
-  const [isEditing, setEditingStatus] = useState(false);
+  const { isEditing, setEditingStatus } = useEditingStatus()
 
   const tableData = [
     {
@@ -63,7 +64,6 @@ const Manager = () => {
     },
   ];
 
-  const handleEditToggle = () => setEditingStatus(!isEditing);
   const onFormikSubmit = (values, { setSubmitting }) => {
     setSubmitting(true);
     setManager({
@@ -104,18 +104,7 @@ const Manager = () => {
 
   return (
     <div className="manager__container">
-      <div className="title__container">
-        <h2>
-          {manager.firstName} {manager.lastName}
-        </h2>
-        <button
-          className={`rounded${isEditing ? "--is-editing" : ""}`}
-          onClick={handleEditToggle}
-          disabled={isEditing}
-        >
-          <i className="fas fa-pen icon"></i>
-        </button>
-      </div>
+      <TitleAndPen manager={manager} isEditing={isEditing} setEditingStatus={setEditingStatus} />
       <div className="manager__contact">
         <h1 className="secondary-title">CONTACT</h1>
         <div className="contact-details">

--- a/src/views/emergencyContacts.js
+++ b/src/views/emergencyContacts.js
@@ -45,7 +45,6 @@ const EmergencyContact = ({ isEditing, handleDelete, id, name, description, cont
 const EmergencyContacts = () => {
     const userContext = useContext(UserContext);
     const [apiContacts, setApiContacts] = useState([]);
-    const [editMode, setEditMode] = useState(false);
     const { isEditing, setEditingStatus } = useEditingStatus()
 
     useMountEffect(() => {

--- a/src/views/emergencyContacts.js
+++ b/src/views/emergencyContacts.js
@@ -4,6 +4,7 @@ import UserContext from '../UserContext';
 import useMountEffect from '../utils/useMountEffect';
 import { Link, useHistory } from "react-router-dom"
 import { useState } from 'react';
+import TitleAndPen, { useEditingStatus } from '../components/TitleAndPen';
 
 const makeAuthHeaders = ({ user }) => ({ headers: { 'Authorization': `Bearer ${user.accessJwt}` } });
 
@@ -15,12 +16,12 @@ const EmergencyContact = ({ isEditing, handleDelete, id, name, description, cont
 
     return (
         <div className="emergencyContact__row">
-            {isEditing && 
+            {isEditing &&
                 <div className="emergencyContact__delete_action" onClick={handleContactDelete}>
                     <i className="fas fa-minus-circle icon"></i>
                 </div>
             }
-            <div className={`emergencyContact__main_column ${isEditing ? 'active' : '' }`} onClick={handleContactEdit}>
+            <div className={`emergencyContact__main_column ${isEditing ? 'active' : ''}`} onClick={handleContactEdit}>
                 {name}
                 <div className="subtext">{description}</div>
             </div>
@@ -45,23 +46,23 @@ const EmergencyContacts = () => {
     const userContext = useContext(UserContext);
     const [apiContacts, setApiContacts] = useState([]);
     const [editMode, setEditMode] = useState(false);
+    const { isEditing, setEditingStatus } = useEditingStatus()
 
     useMountEffect(() => {
-      axios
-          .get(`/api/emergencycontacts`, makeAuthHeaders(userContext))
-          .then(({ data }) => {
-              setApiContacts(data.emergency_contacts);
-          })
-          .catch(error => alert(error));
-  });
+        axios
+            .get(`/api/emergencycontacts`, makeAuthHeaders(userContext))
+            .then(({ data }) => {
+                setApiContacts(data.emergency_contacts);
+            })
+            .catch(error => alert(error));
+    });
 
-    const handleStartEditing = () => setEditMode(true);
     const handleDoneEditing = () => {
-        setEditMode(false);
+        setEditingStatus(false);
     }
     const handleDelete = id => {
         const continueDelete = window.confirm('Are you sure you want to delete the emergency contact?');
-        if(!continueDelete) return;
+        if (!continueDelete) return;
         axios
             .delete(`/api/emergencycontacts/${id}`, makeAuthHeaders(userContext))
             .then(() => {
@@ -73,10 +74,8 @@ const EmergencyContacts = () => {
     return (
         <div className="emergency_contacts__container">
             <div className="section-header">
-                <div className="page-title">
-                    <h2>Emergency Numbers</h2>
-                    <div className="rounded" onClick={handleStartEditing}><i className="fas fa-pen icon"></i></div>
-                </div>
+                <TitleAndPen title="Emergency Numbers" isEditing={isEditing} setEditingStatus={setEditingStatus} />
+
                 <Link className="is-rounded" to="/add/emergencyContact">
                     <i className="fas fa-plus-circle"></i> Create Emergency Number
                 </Link>
@@ -85,12 +84,12 @@ const EmergencyContacts = () => {
                 <div className="row_container">
                     {
                         apiContacts.map(contact => (
-                            <EmergencyContact key={contact.id} isEditing={editMode} handleDelete={handleDelete} { ...contact } />
+                            <EmergencyContact key={contact.id} isEditing={isEditing} handleDelete={handleDelete} {...contact} />
                         ))
                     }
                 </div>
             </div>
-            {editMode &&
+            {isEditing &&
                 <div className="section-footer">
                     <button className="active button is-rounded" onClick={handleDoneEditing}>DONE</button>
                 </div>


### PR DESCRIPTION
### What issue is this solving?
closes #242 

TitleAndPen takes title, isEditing, and setEditingStatus as props.
isEditing and setEditingStatus are in a hook that must be imported by name <useEditingStatus> from "....../components/TitleAndPen" 
i.e <import TitleAndPen, { useEditingStatus } from '../components/TitleAndPen';>
in the parent component it would mirror useState but deconstruct with brackets as it is exported as an object: ei <const { isEditing, setEditingStatus } = useEditingStatus()>

Each instance of useEditingStatus initiates its own state so you could also set these in the parent's state yourself as long as the state and it's setter are passed in TitleAndPen's props.


### Any helpful knowledge/context for the reviewer?
Is a `npm install` necessary? nope
Any special requirements to test? nope

### Please make sure you've attempted to meet the following coding standards
- [ ] Code builds successfully
- [ ] Code has been tested and does not produce errors
- [ ] Code is readable and formatted
- [ ] There isn't any unnecessary commented-out code
- [ ] There aren't any unnecessary commits or files changed (shouldn't touch the /stashed folder unless the issue requests it)

If you're having trouble meeting this criteria, feel free to reach out on Slack for help!