### PR TITLE
Use config file for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,12 +1,3 @@
----
-name: Bug report
-about: Create a report to help us improve
-title: ''
-labels: bug
-assignees: ''
-
----
-
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Bug report
+    about: Create a report to help us improve
+    url: https://github.com/codeforpdx/dwellingly-app/issues/new?template=bug_report.md&labels=bug&projects=codeforpdx/dwellingly-app/4
+  - name: Feature request
+    about: Suggest an idea for this project
+    url: https://github.com/codeforpdx/dwellingly-app/issues/new?template=feature_request.md&projects=codeforpdx/dwellingly-app/4

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,12 +1,3 @@
----
-name: Feature request
-about: Suggest an idea for this project
-title: ''
-labels: ''
-assignees: ''
-
----
-
 **Purpose**
 What will this feature provide?
 


### PR DESCRIPTION
This allows us to select a project automatically for new issues.

### What issue is this solving?
Ensures new issues are automatically added to the kanban board.
