### PR TITLE
Issue 312 - Use `Button` component for buttons in "Request Access" section

### DIFF
--- a/src/components/RequestItem/index.js
+++ b/src/components/RequestItem/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import './requestItem.scss';
+import Button from "../Button";
 
 function RequestItem(props) {
     const { data, onDeclineClick, onAddClick } = props;
@@ -11,8 +12,22 @@ function RequestItem(props) {
                 <a href="#">{email}</a>
             </div>
             <div className="dashboard__colapsible_col collapsible__buttons">
-                <button className="button is-primary is-rounded" onClick={() => { onAddClick(id) }}>ADD</button>
-                <button className="button is-dark is-rounded" onClick={() => { onDeclineClick(id) }}>DECLINE</button>
+                <Button
+                    isCancelButton={false}
+                    type={"submit"}
+                    disabledFlag={false}
+                    isValidFlag={true}
+                    onClick={() => { onAddClick(id) }}
+                >
+                    ADD
+                </Button>
+                <Button
+                    isCancelButton={true}
+                    type={"reset"}
+                    onClick={() => { onDeclineClick(id) }}
+                >
+                    DECLINE
+                </Button>
             </div>
         </div>
     )


### PR DESCRIPTION

Fixes #312 
Prior to this commit, the add/decline buttons in the "Request Access" section
did not use the `Button` component that is used elsewhere, and thus their
styling did not match.  This commit migrates them to the Button component
and now their colors match the rest of the style.

### What issue is this solving?
Please connect this Pull Request to the issue it is resolving by using the controls on the right side of this PR.

### Any helpful knowledge/context for the reviewer?
Is a `npm install` necessary?
Any special requirements to test?

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [ ] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
- [x] There aren't any unnecessary commits or files changed (shouldn't touch the /stashed folder unless the issue requests it)

If you're having trouble meeting this criteria, feel free to reach out on Slack for help!