### PR TITLE
Add Staff Post Request

### DIFF
--- a/src/views/addStaffMember.js
+++ b/src/views/addStaffMember.js
@@ -1,5 +1,7 @@
 import React from "react";
 import { Link } from 'react-router-dom';
+import * as axios from 'axios';
+
 
 
 export const InfoField = ({label, info}) => {
@@ -20,7 +22,16 @@ export const AddStaffMember = () => {
 
 
 	const handleSave = () => {
-		// TODO: Save the new staff member
+
+		data = ""
+
+		// axios.post("/api/properties", data, { headers: {"Authorization" : `Bearer ${context.user.accessJwt}`} })
+        // .then(function(response){
+        //     alert("Staff Added!");
+        // })
+        // .catch(function(error){
+        //     alert(error);
+        // })
 	}
 
 	return (

--- a/src/views/addStaffMember.js
+++ b/src/views/addStaffMember.js
@@ -20,18 +20,36 @@ export const InfoField = ({label, info}) => {
 
 export const AddStaffMember = () => {
 
+	// delete this once form is redone
+	const dummyData = {
+		firstName: "John",
+		lastName: "Souza",
+		phone: "5555555555",
+		email: "emails@email.com",
+		password: "1234",
+		role: 3
+	}
 
 	const handleSave = () => {
 
-		data = ""
+		// TODO: 
+		// 1. Change dummy data to actual data
+		// 2. Create new API endpoint. Currently routes to register. Needs to go to an 
+		// endpoint that is JWT authorized and sends an email to the new email to set their password.
 
-		// axios.post("/api/properties", data, { headers: {"Authorization" : `Bearer ${context.user.accessJwt}`} })
-        // .then(function(response){
-        //     alert("Staff Added!");
-        // })
-        // .catch(function(error){
-        //     alert(error);
-        // })
+		// NOTE: The newly created user will not appear in the users page. The users page is currently
+		// linked to static json data, not the database.
+
+		const data = dummyData 
+
+		axios.post("/api/register", data, { headers: {"Authorization" : `Bearer ${localStorage.getItem("token")}`} })
+        .then(function(response){
+			alert("Staff Added!");
+			console.log(response)
+        })
+        .catch(function(error){
+            alert(error);
+		})
 	}
 
 	return (


### PR DESCRIPTION
New Staff Member page submits data to the backend through axios. Request is filled with dummy data for now. Form will be reworked soon.

Eventually we will need to create a new API endpoint for this request. Right now it goes to the register route. However, this request can create admins and thus requires JWT authorization. We will also need to send an email to the specified address so that they can set their own password.