### PR TITLE
Improve the search bar on the managers page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,7 @@ import {
 import Header from "./components/Header/index";
 import Footer from "./components/Footer/index";
 import { AddProperty } from "./views/addProperty";
-import Managers from "./views/managers";
+import { Managers } from "./views/managers";
 import Manager from "./views/Manager";
 import { JoinStaff } from "./views/joinStaff";
 import { AddStaffMember } from "./views/addStaffMember";

--- a/src/views/managers.js
+++ b/src/views/managers.js
@@ -1,10 +1,11 @@
-import React from "react";
+import React, {Component} from "react";
 import BootstrapTable from "react-bootstrap-table-next";
 import { Link } from "react-router-dom";
 import * as axios from "axios";
 import { PROPERTY_MANAGER_DATA } from "./dummyData/pManagerData";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEnvelope } from "@fortawesome/free-solid-svg-icons";
+import Search from "../components/Search";
 
 const columns = [
   {
@@ -74,11 +75,35 @@ const selectRow = {
   },
 };
 
-const Managers = () => {
+export class Managers extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      managers: PROPERTY_MANAGER_DATA,
+      filteredManagers: [],
+      isFiltered: false
+    }
+  }
+
+  setIsFilteredManagersFalse = async () => {
+    await this.setState({isFiltered: false});
+  }
+
+  setOutputState = async (output, isTrue) => {
+    await  this.setState({
+      filteredManagers: output,
+      isFiltered: isTrue
+    });
+  }
+
+  componentDidMount() {
+    this.setState({managers: PROPERTY_MANAGER_DATA})
+  }
 
   // re-purpose getProperties once API is configured to retrieve tenant and properties for Property Managers
   // eslint-disable-next-line no-unused-vars
-  const getProperties = (context) => {
+  getProperties = (context) => {
     axios
       .get(`${process.env.REACT_APP_API_URL}/properties`, {
         headers: { Authorization: `Bearer ${context.user.accessJwt}` },
@@ -92,37 +117,45 @@ const Managers = () => {
       });
   };
 
-  return (
-    <div className="managers">
-      <div className="section-header">
-        <h2 className="page-title">Property Managers</h2>
-        <Link className="button is-rounded" to="/manage/managers">
-          + ADD NEW
-        </Link>
-      </div>
-      <div>
-        <input></input>
-      </div>
-      <div className="invite-button">
-        <button className="button is-rounded" type="submit">
-          <FontAwesomeIcon
-            className="button__envelope-icon"
-            icon={faEnvelope}
-          />{" "}
-          Invite
-        </button>
-      </div>
-      <BootstrapTable
-        keyField="id"
-        data={PROPERTY_MANAGER_DATA}
-        columns={columns}
-        selectRow={selectRow}
-        bootstrap4={true}
-        headerClasses="table-header"
-        wrapperClasses="managers__table"
-      />
-    </div>
-  );
+  render() {
+    return (
+        <div className="managers">
+          <div className="section-header">
+            <h2 className="page-title">Property Managers</h2>
+            <Link className="button is-rounded" to="/manage/managers">
+              + ADD NEW
+            </Link>
+          </div>
+
+          <Search
+              input={this.state.managers} outputLocation={this.state.filteredManagers}
+              isFilteredLocation={this.state.isFiltered}
+              setIsFilteredStateFalse={this.setIsFilteredManagersFalse}
+              setOutputState={this.setOutputState}
+              placeholderMessage="Search properties by name, address, or property manager"
+          />
+
+          <div className="invite-button">
+            <button className="button is-rounded" type="submit">
+              <FontAwesomeIcon
+                  className="button__envelope-icon"
+                  icon={faEnvelope}
+              />{" "}
+              Invite
+            </button>
+          </div>
+          <BootstrapTable
+              keyField="id"
+              data={ this.state.isFiltered === true ? this.state.filteredManagers : this.state.managers }
+              columns={columns}
+              selectRow={selectRow}
+              bootstrap4={true}
+              headerClasses="table-header"
+              wrapperClasses="managers__table"
+          />
+        </div>
+
+    );
+  }
 };
 
-export default Managers;


### PR DESCRIPTION

Fixes #315 

This commit changes the search field on the managers page from
an input box to a `Search` widget, which improves the styling and
wires up the search functions.

We also convert the Managers object to a `Component` to prepare
for wiring it with real data.  It still uses the hard-coded
data for now, but the search box can successfully filter against
the hard-coded data.

### What issue is this solving?
Please connect this Pull Request to the issue it is resolving by using the controls on the right side of this PR.

### Any helpful knowledge/context for the reviewer?
Is a `npm install` necessary?
Any special requirements to test?

### Please make sure you've attempted to meet the following coding standards
- [ ] Code builds successfully
- [ ] Code has been tested and does not produce errors
- [ ] Code is readable and formatted
- [ ] There isn't any unnecessary commented-out code
- [ ] There aren't any unnecessary commits or files changed (shouldn't touch the /stashed folder unless the issue requests it)

If you're having trouble meeting this criteria, feel free to reach out on Slack for help!