### PR TITLE
Fix failures in signup test

### DIFF
--- a/src/views/signup.test.js
+++ b/src/views/signup.test.js
@@ -5,6 +5,8 @@ import '@testing-library/jest-dom/extend-expect';
 import SignupForm from "./signup";
 import UserContext from "../UserContext";
 
+import { MemoryRouter } from "react-router";
+
 const mockHistory = { push: jest.fn() };
 jest.spyOn(axios, 'post').mockResolvedValue({});
 jest.spyOn(window, 'alert').mockImplementation(() => {});
@@ -21,9 +23,11 @@ describe("signup component", () => {
 
   beforeEach(() => {
     view = render(
-      <UserContext.Provider value={{ user: mockNotAuthenticatedUser }}>
-        <SignupForm history={mockHistory} />
-      </UserContext.Provider>
+        <MemoryRouter>
+          <UserContext.Provider value={{ user: mockNotAuthenticatedUser }}>
+            <SignupForm history={mockHistory} />
+          </UserContext.Provider>
+        </MemoryRouter>
     );
   });
 


### PR DESCRIPTION
signup tests were missing a Router context, so failing with
an error about using a Link outside of a Router.  This commit just
adds a Router, and now the tests pass.

### What issue is this solving?
Please connect this Pull Request to the issue it is resolving by using the controls on the right side of this PR.

### Any helpful knowledge/context for the reviewer?
Is a `npm install` necessary?
Any special requirements to test?

### Please make sure you've attempted to meet the following coding standards
- [ ] Code builds successfully
- [ ] Code has been tested and does not produce errors
- [ ] Code is readable and formatted
- [ ] There isn't any unnecessary commented-out code
- [ ] There aren't any unnecessary commits or files changed (shouldn't touch the /stashed folder unless the issue requests it)

If you're having trouble meeting this criteria, feel free to reach out on Slack for help!