### PR TITLE
Fix header test failures

### DIFF
--- a/src/components/Header/header.test.js
+++ b/src/components/Header/header.test.js
@@ -4,6 +4,13 @@ import Header from "./index";
 
 import dwellinglylogo from "../../assets/images/dwellingly_logo_white.png";
 
+
+jest.mock("react-router-dom", () => ({
+	...jest.requireActual("react-router-dom"),
+	useLocation: () => ({ pathname: "/manage/managers" }),
+	useParams: jest.fn(),
+}));
+
 const setUp = (props = {}) => {
 	const component = shallow(<Header {...props} />);
 	return component;


### PR DESCRIPTION
The header tests were failing because `useLocation` can't be called
outside of a router.  This commit adds a mock for `useLocation` so that
the test will pass (pattern copied from footer test).

After this and #329, all frontend tests should be green.

### What issue is this solving?
Please connect this Pull Request to the issue it is resolving by using the controls on the right side of this PR.

### Any helpful knowledge/context for the reviewer?
Is a `npm install` necessary?
Any special requirements to test?

### Please make sure you've attempted to meet the following coding standards
- [ ] Code builds successfully
- [ ] Code has been tested and does not produce errors
- [ ] Code is readable and formatted
- [ ] There isn't any unnecessary commented-out code
- [ ] There aren't any unnecessary commits or files changed (shouldn't touch the /stashed folder unless the issue requests it)

If you're having trouble meeting this criteria, feel free to reach out on Slack for help!