### PR TITLE
Update issue template config to auto add FE BE labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,14 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Bug report
+  - name: 'Frontend: Bug report'
     about: Create a report to help us improve
-    url: https://github.com/codeforpdx/dwellingly-app/issues/new?template=bug_report.md&labels=bug&projects=codeforpdx/dwellingly-app/4
-  - name: Feature request
+    url: https://github.com/codeforpdx/dwellingly-app/issues/new?template=bug_report.md&labels=bug,FRONTEND&projects=codeforpdx/dwellingly-app/4
+  - name: 'Frontend: Feature request'
     about: Suggest an idea for this project
-    url: https://github.com/codeforpdx/dwellingly-app/issues/new?template=feature_request.md&projects=codeforpdx/dwellingly-app/4
+    url: https://github.com/codeforpdx/dwellingly-app/issues/new?template=feature_request.md&labels=FRONTEND&projects=codeforpdx/dwellingly-app/4
+  - name: 'Backend: Bug report'
+    about: Create a report to help us improve
+    url: https://github.com/codeforpdx/dwellingly-app/issues/new?template=bug_report.md&labels=bug,BACKEND&projects=codeforpdx/dwellingly-app/4
+  - name: 'Backend: Feature request'
+    about: Suggest an idea for this project
+    url: https://github.com/codeforpdx/dwellingly-app/issues/new?template=feature_request.md&labels=BACKEND&projects=codeforpdx/dwellingly-app/4


### PR DESCRIPTION
This adds two new issue templates so that frontend and backend labels
can be applied accordingly.