### PR TITLE
Improve the search bar on the managers page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,7 +27,7 @@ import {
 import Header from "./components/Header/index";
 import Footer from "./components/Footer/index";
 import { AddProperty } from "./views/addProperty/addProperty";
-import Managers from "./views/managers/managers";
+import { Managers } from "./views/managers/managers";
 import Manager from "./views/Manager";
 import { JoinStaff } from "./views/joinStaff/joinStaff";
 import { AddStaffMember } from "./views/addStaffMember/addStaffMember";

--- a/src/views/managers/managers.js
+++ b/src/views/managers/managers.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {Component} from "react";
 import BootstrapTable from "react-bootstrap-table-next";
 import { Link } from "react-router-dom";
 import * as axios from "axios";
@@ -78,11 +78,35 @@ const selectRow = {
   },
 };
 
-const Managers = () => {
+export class Managers extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      managers: PROPERTY_MANAGER_DATA,
+      filteredManagers: [],
+      isFiltered: false
+    }
+  }
+
+  setIsFilteredManagersFalse = async () => {
+    await this.setState({isFiltered: false});
+  }
+
+  setOutputState = async (output, isTrue) => {
+    await  this.setState({
+      filteredManagers: output,
+      isFiltered: isTrue
+    });
+  }
+
+  componentDidMount() {
+    this.setState({managers: PROPERTY_MANAGER_DATA})
+  }
 
   // re-purpose getProperties once API is configured to retrieve tenant and properties for Property Managers
   // eslint-disable-next-line no-unused-vars
-  const getProperties = (context) => {
+  getProperties = (context) => {
     axios
       .get(`${process.env.REACT_APP_API_URL}/properties`, {
         headers: { Authorization: `Bearer ${context.user.accessJwt}` },
@@ -96,37 +120,45 @@ const Managers = () => {
       });
   };
 
-  return (
-    <div className="managers">
-      <div className="section-header">
-        <h2 className="page-title">Property Managers</h2>
-        <Link className="button is-rounded is-primary ml-4" to="/manage/managers">
-          + ADD NEW
-        </Link>
-      </div>
-      <div>
-        <Search placeholderMessage="Search property managers by name, property, or status" />
-      </div>
-      <div className="invite-button-container py-3">
-        <button className="button is-rounded is-primary ml-3" type="submit">
-          <FontAwesomeIcon
-            className="button__envelope-icon mr-3"
-            icon={faEnvelope}
+  render() {
+    return (
+        <div className="managers">
+          <div className="section-header">
+            <h2 className="page-title">Property Managers</h2>
+            <Link className="button is-rounded is-primary ml-4" to="/manage/managers">
+              + ADD NEW
+            </Link>
+          </div>
+
+          <Search
+              input={this.state.managers} outputLocation={this.state.filteredManagers}
+              isFilteredLocation={this.state.isFiltered}
+              setIsFilteredStateFalse={this.setIsFilteredManagersFalse}
+              setOutputState={this.setOutputState}
+              placeholderMessage="Search properties by name, address, or property manager"
           />
-          Invite
-        </button>
-      </div>
-      <BootstrapTable
-        keyField="id"
-        data={PROPERTY_MANAGER_DATA}
-        columns={columns}
-        selectRow={selectRow}
-        bootstrap4={true}
-        headerClasses="table-header"
-        wrapperClasses="managers__table"
-      />
-    </div>
-  );
+
+          <div className="invite-button-container py-3">
+            <button className="button is-rounded is-primary ml-3" type="submit">
+              <FontAwesomeIcon
+                  className="button__envelope-icon mr-3"
+                  icon={faEnvelope}
+              />{" "}
+              Invite
+            </button>
+          </div>
+          <BootstrapTable
+              keyField="id"
+              data={ this.state.isFiltered === true ? this.state.filteredManagers : this.state.managers }
+              columns={columns}
+              selectRow={selectRow}
+              bootstrap4={true}
+              headerClasses="table-header"
+              wrapperClasses="managers__table"
+          />
+        </div>
+
+    );
+  }
 };
 
-export default Managers;


### PR DESCRIPTION
Fixes #315 
Replaces #328 (because it was based on a fork rather than a feature branch in the main repo)

This commit changes the search field on the managers page from
an input box to a `Search` widget, which improves the styling and
wires up the search functions.

We also convert the Managers object to a `Component` to prepare
for wiring it with real data.  It still uses the hard-coded
data for now, but the search box can successfully filter against
the hard-coded data.

### What issue is this solving?
Please connect this Pull Request to the issue it is resolving by using the controls on the right side of this PR.

### Any helpful knowledge/context for the reviewer?
Is a `npm install` necessary?
Any special requirements to test?

### Please make sure you've attempted to meet the following coding standards
- [ ] Code builds successfully
- [ ] Code has been tested and does not produce errors
- [ ] Code is readable and formatted
- [ ] There isn't any unnecessary commented-out code
- [ ] There aren't any unnecessary commits or files changed (shouldn't touch the /stashed folder unless the issue requests it)

If you're having trouble meeting this criteria, feel free to reach out on Slack for help!