### PR TITLE
Fix links in contributing.md

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -14,8 +14,8 @@ This document provides some overall guidelines and suggestions for how to get st
 ### First steps
 
 * Set up your local dev environment [here](README.md#Getting-Started) and [here](https://github.com/codeforpdx/dwellinglybackend/blob/development/README.md#to-start-server)
-* Be sure to read our [Code of Conduct](http://www.codeforpdx.org/about/conduct)
-* Join our [Slack Workspace](https://codeforpdx.slack.com/) and say "Hi" in the #dwellingly-join channel
+* Be sure to read our [Code of Conduct](https://github.com/codeforpdx/codeofconduct)
+* Join our [Slack Workspace](https://join.slack.com/t/codeforpdx/shared_invite/zt-4msr5np3-n5qBye3GG~4hA_7XZkczgA) and say "Hi" in the #dwellingly-join channel
 * Come visit at a [Project Night](https://www.meetup.com/Code-for-PDX/events/) and get to know us
 
 ----


### PR DESCRIPTION
### Changes:

- Changed Code of Conduct link to correct url
- Changed Slack link to workspace invite link for improved onboarding

### What issue is this solving?

This is a **documentation fix**. 

The current link to the Code of Conduct directs to a 404 page: https://www.codeforpdx.org/about/conduct instead of the Code of Conduct here on GitHub.

The current link is to the Slack workspace, but this only gives two options: "Continue with Google" or signing in with an active workspace email.  The "Sign Up" option only lets users sign up if they have emails ending in "@codeforpdx.org", "@codeforamerica.org", or "@ronbronson.com".
The correct link is the _invite link_, which allows anyone to join/sign up.

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
- [x] There aren't any unnecessary commits or files changed (shouldn't touch the /stashed folder unless the issue requests it)
