### PR TITLE
435 dashboard links

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -44,16 +44,33 @@ export class App extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      userSession: {
-        isAuthenticated: false,
-        accessJwt: '',
-        refreshJwt: '',
-        identity: '',
-        firstName: '',
-        lastName: '',
-        email: '',
-        phone: '',
+    if (checkForStoredAccessToken()) {
+      let parsedJwt = parseJwt(window.localStorage['dwellinglyAccess']);
+      this.state = {
+        userSession: {
+          isAuthenticated: true,
+          accessJwt: window.localStorage["dwellinglyAccess"],
+          refreshJwt: window.localStorage["dwellinglyRefresh"],
+          identity: parsedJwt.identity,
+          firstName: parsedJwt.user_claims.firstName,
+          lastName: parsedJwt.user_claims.lastName,
+          email: parsedJwt.user_claims.email,
+          phone: parsedJwt.user_claims.phone
+        }
+      }
+    }
+    else {
+      this.state = {
+        userSession: {
+          isAuthenticated: false,
+          accessJwt: '',
+          refreshJwt: '',
+          identity: '',
+          firstName: '',
+          lastName: '',
+          email: '',
+          phone: '',
+        }
       }
     }
   }
@@ -71,7 +88,7 @@ export class App extends React.Component {
             firstName: parsedJwt.user_claims.firstName,
             lastName: parsedJwt.user_claims.lastName,
             email: parsedJwt.user_claims.email,
-            phone: parsedJwt.user_claims.phone,
+            phone: parsedJwt.user_claims.phone
           },
         },
         () => {

--- a/src/components/DashboardModule/index.js
+++ b/src/components/DashboardModule/index.js
@@ -10,14 +10,14 @@ function DashboardModule(props) {
 
     return (
         <div className="dashboard__module">
-            <div className="dashboard__module_header">
-                <a href={data.link || "#"}>
+            <a href={data.link || "#"}>
+                <div className="dashboard__module_header">
                     <h3 className="dashboard__module_title h2">{data.title}</h3>
-                    <span className="icon dashboard__module_title_linik">
+                    <span className="icon dashboard__module_title_link">
                         <i className="fas fa-chevron-right"></i>
                     </span>
-                </a>
-            </div>
+                </div>
+            </a>
             {
                 data.stats.map((statRow, index) => {
                     return (

--- a/src/components/DashboardModule/index.js
+++ b/src/components/DashboardModule/index.js
@@ -11,16 +11,12 @@ function DashboardModule(props) {
     return (
         <div className="dashboard__module">
             <div className="dashboard__module_header">
-                <h3 className="dashboard__module_title h2">{data.title}</h3>
-                {
-                    data.link && (
-                        <a href={data.link} className="dashboard__module_title_link">
-                            <span className="icon">
-                                <i className="fas fa-chevron-right"></i>
-                            </span>
-                        </a>
-                    )
-                }
+                <a href={data.link || "#"}>
+                    <h3 className="dashboard__module_title h2">{data.title}</h3>
+                    <span className="icon dashboard__module_title_linik">
+                        <i className="fas fa-chevron-right"></i>
+                    </span>
+                </a>
             </div>
             {
                 data.stats.map((statRow, index) => {


### PR DESCRIPTION
The cards on the dashboard which are intended to link to their respective detail pages, are now clickable across the entire title line. (See issue #435) An additional backend pull request will provide the actual links to those pages, since the current structure accepts the link data as part of the API payload.

In addition, while testing this I discovered that many detail pages were *only* accessible via the nav menu - my new links, and simply typing the appropriate URL, would redirect to the dashboard. This turned out to be caused by the authorization logic setting its state twice, first in the app constructor and then again in componentDidMount. This pull request moves the authorization logic into the constructor, fixing the issue and roughly halving the app's load time as a side effect.
