### PR TITLE
Fix propertyUrl for TenantView

### DIFF
--- a/src/views/Tenant/TenantView.js
+++ b/src/views/Tenant/TenantView.js
@@ -113,7 +113,7 @@ const Tenant = () => {
   const getTenant = async () => {
     const tenantResponse = await client.get(`/api/tenants/${id}`);
     const tenant = tenantResponse.data;
-    const propertyUrl = `/api/properties/${tenant.propertyName}`;
+    const propertyUrl = `/api/properties/${tenant.propertyID}`;
     const propertyResponse = await client.get(propertyUrl);
     const property = propertyResponse.data;
     const ticketsResponse = await client.get(`/api/tickets?tenant=${tenant.id}`);


### PR DESCRIPTION
### What issue is this solving?
No issue that I know of.  I discovered this when looking into the error @DaveTrost brought up on Slack.

The tenant view's `getTenant` was still trying to access the property by name, resulting in an error page when trying to view an individual tenant.

**Changes**:

- Updated `getTenant` to access property by id.

### Any helpful knowledge/context for the reviewer?
Is a `npm install` necessary? NO
Any special requirements to test? NO

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
- [x] There aren't any unnecessary commits or files changed (shouldn't touch the /stashed folder unless the issue requests it)

If you're having trouble meeting this criteria, feel free to reach out on Slack for help!