### PR TITLE
Remove PENDING role from frontend

### DIFF
--- a/src/Enums/RoleEnum.js
+++ b/src/Enums/RoleEnum.js
@@ -1,5 +1,4 @@
 const RoleEnum = {
-    PENDING: 0,
     PROPERTY_MANAGER: 2,
     STAFF: 3,
     ADMIN: 4

--- a/src/views/dashboard/dashboard.jsx
+++ b/src/views/dashboard/dashboard.jsx
@@ -55,7 +55,7 @@ export const Dashboard = (props) => {
 
   const getPendingUsers = async () => {
     await axios
-      .post("/api/users/role", { "userrole": RoleEnum.PENDING }, makeAuthHeaders(userContext))
+      .get("/api/users/pending", makeAuthHeaders(userContext))
       .then(({ data }) => setUsersPending(data.users))
       .catch(error => Toast(error.message, "error"));
   };

--- a/src/views/requestAccess/requestAccess.jsx
+++ b/src/views/requestAccess/requestAccess.jsx
@@ -73,9 +73,8 @@ export const RequestAccess = (props) => {
         let data = JSON.parse(response.data);
         // Get Role names
         let roleArray = Object.keys(data);
-        // Remove "Pending" role and replace _'s with spaces where existing
-        roleArray = roleArray.filter( role => role !== "PENDING" )
-          .map( role => role.replace('_', ' '));
+        // Replace _'s with spaces where existing
+        roleArray = roleArray.map(role => role.replace('_', ' '));
         // Get array of roles to map to selection options
         setSelectionOptions(roleArray);
       })


### PR DESCRIPTION
### What issue is this solving?
Closes #503 

- Removes PENDING role from `RoleEnum` 
- Dashboard uses the new users/pending endpoint to pull info for users
    awaiting access to the app
- `requestAccess.jsx` no longer has to filter out the PENDING role when
    creating the dropdown for role assignment

### Any helpful knowledge/context for the reviewer?
Is a `npm install` necessary? NO
Any special requirements to test?
In order to see the changes in the frontend, this should be tested using my branch from [backend PR 214](https://github.com/codeforpdx/dwellinglybackend/pull/214)

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
- [x] There aren't any unnecessary commits or files changed (shouldn't touch the /stashed folder unless the issue requests it)

If you're having trouble meeting this criteria, feel free to reach out on Slack for help!