### PR TITLE
overhauls tenants page to meet FIGMA requirements and adds ToolTip 

### DIFF
--- a/src/components/PropertyManagerCard/PropertyManagerCard.jsx
+++ b/src/components/PropertyManagerCard/PropertyManagerCard.jsx
@@ -24,6 +24,7 @@ function PropertyManagerCard({ manager, isEditing, removePropertyManager }) {
         <FontAwesomeIcon
           icon={faTimesCircle}
           onClick={() => removePropertyManager(manager.id)}
+          className={"remove-manager-button"}
         />
         :
         <></>}

--- a/src/components/PropertyManagerCard/PropertyManagerCard.jsx
+++ b/src/components/PropertyManagerCard/PropertyManagerCard.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Link } from "react-router-dom";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 import './PropertyManagerCard.scss';
 import '../ManagerSearchPanel/ManagerSearchPanel';
 import Icon from '../icon/Icon';
@@ -19,9 +21,11 @@ function PropertyManagerCard({ manager, isEditing, removePropertyManager }) {
         <p className="information">{manager.email}</p>
       </div>
       {isEditing ?
-        <button onClick={() => removePropertyManager(manager.id)}>
-          <Icon id="close-icon" icon="close" />
-        </button> :
+        <FontAwesomeIcon
+          icon={faTimesCircle}
+          onClick={() => removePropertyManager(manager.id)}
+        />
+        :
         <></>}
     </div >
   )

--- a/src/components/PropertyManagerCard/PropertyManagerCard.scss
+++ b/src/components/PropertyManagerCard/PropertyManagerCard.scss
@@ -9,3 +9,7 @@
     color: $primary;
   }
 }
+
+.remove-manager-button:hover {
+  cursor: pointer
+}

--- a/src/components/PropertyManagerCard/PropertyManagerCard.scss
+++ b/src/components/PropertyManagerCard/PropertyManagerCard.scss
@@ -1,6 +1,7 @@
 @import "../../scss/variables.scss";
 .property-manager-box{
     width: 50%;
+    max-width: 400px;
     height: 120px;
     display: flex;
     justify-content: space-between;

--- a/src/components/ShowHideSwitch/index.js
+++ b/src/components/ShowHideSwitch/index.js
@@ -5,13 +5,13 @@ export const ShowHideSwitch = ({ id, labelText, isShowState, handleToggleChange 
   <div key={id} className="showHideSwitch">
     <label className="switchLabel">{labelText}</label>
     <div className="switchToggle">
-      <input 
-        type="checkbox" 
-        id="switch"
+      <input
+        type="checkbox"
+        id={`switch${id}`}
         value={isShowState}
         onChange={handleToggleChange}
       />
-      <label htmlFor="switch">show/hide</label>
+      <label htmlFor={`switch${id}`}>show/hide</label>
     </div>
   </div>
 );

--- a/src/components/ToolTip/ToolTip.jsx
+++ b/src/components/ToolTip/ToolTip.jsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import "./ToolTip.scss";
+
+const Tooltip = ({ delay, children, direction, content }) => {
+  let timeout;
+  const [active, setActive] = useState(false);
+
+  const showTip = () => {
+    timeout = setTimeout(() => {
+      setActive(true);
+    }, delay || 400);
+  };
+
+  const hideTip = () => {
+    clearInterval(timeout);
+    setActive(false);
+  };
+
+  return (
+    <div
+      className="Tooltip-Wrapper"
+      onMouseEnter={showTip}
+      onMouseLeave={hideTip}
+    >
+      {children}
+      {active && (
+        <div className={`Tooltip-Tip ${direction || "top"}`}>
+          {content}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default Tooltip;

--- a/src/components/ToolTip/ToolTip.scss
+++ b/src/components/ToolTip/ToolTip.scss
@@ -1,0 +1,88 @@
+@import "../../scss/variables.scss";
+
+$tooltip-text-color: $white;
+$tooltip-background-color: $darkGray;
+$tooltip-margin-top: 35px;
+$tooltip-margin-side: 10px;
+$tooltip-arrow-size: 6px;
+
+
+.Tooltip-Wrapper {
+  display: inline-block;
+  position: relative;
+}
+
+.Tooltip-Tip {
+  position: absolute;
+  border-radius: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 6px;
+  color: $tooltip-text-color;
+  background: $tooltip-background-color;
+  font-size: 14px;
+  line-height: 1;
+  z-index: 100;
+  white-space: nowrap;
+
+  &:before {
+    content: " ";
+    left: 50%;
+    border: solid transparent;
+    height: 0;
+    width: 0;
+    position: absolute;
+    pointer-events: none;
+    border-width: $tooltip-arrow-size;
+    margin-left: calc(#{$tooltip-arrow-size} * -1)
+  }
+
+  &.top {
+    top: calc(#{$tooltip-margin-top} * -1);
+    border-top-color: $tooltip-background-color;
+
+    &:before{
+      top: 100%;
+      border-top-color: $tooltip-background-color;
+    }
+  }
+
+
+  &.right {
+    left: calc(100% + #{$tooltip-margin-side});
+    top: 50%;
+    transform: translateX(0) translateY(-50%);
+
+    &:before {
+      left: calc(#{$tooltip-arrow-size} * -1);
+      top: 50%;
+      transform:translateX(0) translateY(-50%);
+      border-right-color: $tooltip-background-color;
+    }
+  }
+  
+  &.bottom{
+    bottom: calc(#{$tooltip-margin-top} * -1);
+    
+    &:before {
+      bottom: 100%;
+      border-bottom-color: $tooltip-background-color;
+    }
+  }
+  
+  &.left {
+    left: auto;
+    right: calc(100% + #{$tooltip-margin-side});
+    top: 50%;
+    transform: translateX(0) translateY(-50%);
+    
+    &:before {
+      left: auto;
+      right: calc(#{$tooltip-arrow-size} * -2);
+      top: 50%;
+      transform: translateX(0) translateY(-50%);
+      border-left-color: $tooltip-background-color;
+    }
+  }
+}
+

--- a/src/views/Manager/index.jsx
+++ b/src/views/Manager/index.jsx
@@ -122,51 +122,63 @@ const Manager = () => {
     setEditingStatus(false);
   };
 
-  return managerData ? (
-    <div className="manager__container">
-      <TitleAndPen title={`${managerData.firstName} ${managerData.lastName}`} isEditing={isEditing} setEditingStatus={setEditingStatus} />
-      <div className="manager__contact">
-        <h1 className="secondary-title">CONTACT</h1>
-        <div className="contact-details">
-          <ToggleEditTable
-            tableData={tableData}
-            validationSchema={validationSchema}
-            isEditing={isEditing}
-            submitHandler={onFormikSubmit}
-            cancelHandler={onCancelClick}
-          />
-        </div>
-      </div>
-      <div className="manager__properties">
-        <h1 className="secondary-title">PROPERTIES</h1>
-        <div className="manager__properties__container">
-          {managerData.properties.map((property) => (
-            <div key={property.id} className="manager__property__tile">
-              <h3 className="manager__property__name">
-                {property.name}
-              </h3>
-              <div className="manager__property__address">
-                {property.streetAddress}
+  return (
+    <div className='main-container'>
+      <div>
+        {managerData ? (
+          <div>
+            <TitleAndPen
+              title={`${managerData.firstName} ${managerData.lastName}`}
+              isEditing={isEditing}
+              setEditingStatus={setEditingStatus}
+            />
+            <div className="section-container">
+              <h2 className="secondary-title">CONTACT</h2>
+            </div>
+            <ToggleEditTable
+              tableData={tableData}
+              validationSchema={validationSchema}
+              isEditing={isEditing}
+              submitHandler={onFormikSubmit}
+              cancelHandler={onCancelClick}
+            />
+            <div className="section-container">
+              <h2 className="secondary-title">PROPERTIES</h2>
+              <div className="manager__properties__container">
+                {managerData.properties.map((property) => (
+                  <div key={property.id} className="manager__property__tile">
+                    <h3 className="manager__property__name">
+                      {property.name}
+                    </h3>
+                    <div className="manager__property__address">
+                      {property.address}
+                      <br />
+                      {`${property.city}, ${property.state}`}
+                      <br />
+                      {property.zipcode}
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
-          ))}
-        </div>
-      </div>
-      <div className="manager__tenants">
-        <h1 className="section-title">TENANTS</h1>
-        {managerData.tenants.map((tenant) =>
-          <div key={tenant.id} className="columns tenant__form-row">
-            <div className="column is-one-quarter bold tenant__name">
-              {tenant.fullName}
+            <div className="manager__tenants">
+              <h1 className="section-title">TENANTS</h1>
+              {managerData.tenants.map((tenant) =>
+                <div key={tenant.id} className="columns tenant__form-row">
+                  <div className="column is-one-quarter bold tenant__name">
+                    {tenant.fullName}
+                  </div>
+                  <div className="column is-one-quarter">{tenant.propertyName}</div>
+                  <div className="column is-one-quarter">Unit #{tenant.unitNum}</div>
+                  <div className="column is-one-quarter">{tenant.phone}</div>
+                </div>
+              )}
             </div>
-            <div className="column is-one-quarter">{tenant.propertyName}</div>
-            <div className="column is-one-quarter">Unit #{tenant.unitNum}</div>
-            <div className="column is-one-quarter">{tenant.phone}</div>
           </div>
-        )}
+        ) : null}
       </div>
-    </div>
-  ) : null;
+    </div >
+  )
 };
 
 export default Manager;

--- a/src/views/Property/PropertyView.jsx
+++ b/src/views/Property/PropertyView.jsx
@@ -199,10 +199,12 @@ const Property = () => {
     const leaseId = tenantToRemove.lease.id;
     axios
       .delete(`${process.env.REACT_APP_PROXY}/api/lease/${leaseId}`)
-      .then(res => getProperty())
-      .then(setConfirmTenantRemoval(false))
-      .then(setEditingStatus(false))
-      .then(Toast("Tenant successfully removed"))
+      .then(res => {
+        getProperty()
+        setConfirmTenantRemoval(false)
+        setEditingStatus(false)
+        Toast("Tenant successfully removed")
+      })
       .catch(error => Toast(error.message))
   }
 

--- a/src/views/Property/PropertyView.scss
+++ b/src/views/Property/PropertyView.scss
@@ -4,3 +4,9 @@
   flex-direction: row;
   width: 100%;
 }
+
+.remove-tenant-icon{
+  display: flex;
+  justify-content: center;
+  cursor: pointer;
+}

--- a/src/views/Property/RemoveTenantButton.jsx
+++ b/src/views/Property/RemoveTenantButton.jsx
@@ -1,20 +1,26 @@
 import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
+import "./PropertyView.scss"
 
 
 
 function RemoveTenantButton({ tenant, removeTenant, isEditing }) {
 
   return (
-    <>
+    <div className="remove-tenant-icon">
       {
         isEditing
           ?
-          < button onClick={() => removeTenant(tenant)
-          }> X</button >
+          <FontAwesomeIcon
+            icon={faTimesCircle}
+            onClick={() => removeTenant(tenant)}
+          />
+
           :
           <></>
       }
-    </>
+    </div>
   )
 }
 

--- a/src/views/tenants/tenants.jsx
+++ b/src/views/tenants/tenants.jsx
@@ -103,7 +103,12 @@ export function Tenants() {
   const handleToggleHoused = () => {
     const newShowHoused = !showHoused;
     setShowHoused(newShowHoused)
-    setDisplayTenants(getDisplayTenants(allTenants, !showHoused, showArchived));
+
+    if (isSearchActive) {
+      setDisplayTenants(getDisplayTenants(searchedTenants, !showHoused, showArchived));
+    } else {
+      setDisplayTenants(getDisplayTenants(allTenants, !showHoused, showArchived));
+    }
     const newSelectedTentants = getDisplayTenants(selectedTenants, !showHoused, showArchived)
     setSelectedTenants(newSelectedTentants);
   }
@@ -112,7 +117,6 @@ export function Tenants() {
     setSearchedTenants(allTenants);
     setIsSearchActive(false);
     setDisplayTenants(getDisplayTenants(allTenants, showHoused, showArchived));
-
   }
 
   const handleSearchOutput = (output, isTrue) => {
@@ -125,7 +129,12 @@ export function Tenants() {
   const handleToggleArchived = () => {
     const newShowArchived = !showArchived;
     setShowArchived(newShowArchived);
-    setDisplayTenants(getDisplayTenants(allTenants, showHoused, !showArchived));
+
+    if (isSearchActive) {
+      setDisplayTenants(getDisplayTenants(searchedTenants, showHoused, !showArchived));
+    } else {
+      setDisplayTenants(getDisplayTenants(allTenants, showHoused, !showArchived));
+    }
   }
 
   const toggleArchiveModal = () => {
@@ -240,21 +249,22 @@ export function Tenants() {
       </div >
       {showArchiveModal &&
         <Modal
+          titleText={selectedTenants.length > 1 ? "Archive Tenants" : "Archive Tenant"}
           content={
             <div>
               <p>You have selected the following {selectedTenants.length} tenants to be archived: </p>
               <ul>
                 {selectedTenants.map(tenant => (
-                  <p
+                  <li
                     key={tenant.fullName}
                     className="archive-tenants-list has-text-weight-bold">
                     {tenant.fullName}
-                  </p>
+                  </li>
                 )
 
                 )}
                 <br />
-                <p>Are you sure you want to archive these properties?</p>
+                <p>Are you sure you want to archive these tenants?</p>
               </ul>
             </div>
           }

--- a/src/views/tenants/tenants.jsx
+++ b/src/views/tenants/tenants.jsx
@@ -242,10 +242,20 @@ export function Tenants() {
         <Modal
           content={
             <div>
-              <p>Are you sure you want to archive </p>
-              {selectedTenants.map(tenant => {
-                return <p key={tenant.fullName}>{tenant.fullName}</p>
-              })}
+              <p>You have selected the following {selectedTenants.length} tenants to be archived: </p>
+              <ul>
+                {selectedTenants.map(tenant => (
+                  <p
+                    key={tenant.fullName}
+                    className="archive-tenants-list has-text-weight-bold">
+                    {tenant.fullName}
+                  </p>
+                )
+
+                )}
+                <br />
+                <p>Are you sure you want to archive these properties?</p>
+              </ul>
             </div>
           }
           hasButtons={true}

--- a/src/views/tenants/tenants.jsx
+++ b/src/views/tenants/tenants.jsx
@@ -1,140 +1,144 @@
-import React, { Component } from 'react';
+import React, { useContext, useState } from 'react';
 import BootstrapTable from 'react-bootstrap-table-next';
-import UserContext from '../../UserContext';
 import axios from "axios";
 import { Link } from "react-router-dom";
-import Search from "../../components/Search/index";
+
+
+import UserContext from '../../UserContext';
+import useMountEffect from '../../utils/useMountEffect';
 import Toast from '../../utils/toast';
+import Search from "../../components/Search/index";
+import { ShowHideSwitch } from '../../components/ShowHideSwitch';
 
-const columns = [
-  {
-    dataField: "fullName",
-    formatter: (cell, row, rowIndex, formatExtraData) => {
-      return (
-        <Link key={row.id} to={`/manage/tenants/${row.id}`}>
-          {row.fullName}
-        </Link>
-      );
-    },
-    text: "Name",
-    sort: true,
-  },
-  {
-    dataField: "propertyName",
-    text: "Property",
-    sort: true,
-  },
-  {
-    dataField: "phone",
-    text: "Phone",
-    sort: true,
-  },
-];
+import { columns } from './tenantsFormStructure'
+import './tenants.scss'
 
-const selectRow = {
-  mode: "checkbox",
-  clickToSelect: true,
-  sort: true,
-  headerColumnStyle: () => {
-    return { width: "5%" };
-  },
-};
+const makeAuthHeaders = ({ user }) => ({ headers: { 'Authorization': `Bearer ${user.accessJwt}` } });
 
-// const pageButtonRenderer = ({
-//   page,
-//   active,
-//   disable,
-//   title,
-//   onPageChange
-// }) => {
-//   const handleClick = (e) => {
-//     e.preventDefault();
-//     onPageChange(page);
-//   };
-//   const activeStyle = {};
-//   if (active) {
-//     activeStyle.backgroundColor = 'black';
-//     activeStyle.color = 'white';
-//   } else {
-//     activeStyle.backgroundColor = 'gray';
-//     activeStyle.color = 'black';
-//   }
-//   if (typeof page === 'string') {
-//     activeStyle.backgroundColor = 'white';
-//     activeStyle.color = 'black';
-//   }
-//   return (
-//     <li className="page-item">
-//       <a href="#" onClick={ handleClick } style={ activeStyle }>{ page }</a>
-//     </li>
-//   );
-// };
+const addPropertyNames = ((tenants, allProperties) => {
+  return tenants.map(tenant => {
+    if (tenant.lease) {
+      const propertyIndex = allProperties.findIndex(property =>
+        property.id === tenant.lease.propertyID)
+      tenant.propertyName = allProperties[propertyIndex].name
+    }
+    return tenant
+  });
+});
 
-// const options = {
-//   pageButtonRenderer
-// };
+const formatTenantData = tenants => tenants.map(tenant => {
+  const { id, lease, phone, fullName } = tenant;
+  const staff = tenant.staff.map(staff => {
+    return `${staff.firstName} ${staff.lastName}`
+  })
+  return { id, lease, phone, fullName, staff }
+})
 
-export class Tenants extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      tenants: [],
-    };
-
-    this.getTenants = this.getTenants.bind(this);
+const sortTenantData = tenants => tenants.sort((a, b) => {
+  if (a.fullName < b.fullName) {
+    return -1;
   }
-
-  componentDidMount() {
-    this.getTenants(this.context);
+  if (a.fullName > b.fullName) {
+    return 1;
   }
+  return 0;
+})
 
-  getTenants = (context) => {
-    axios
-      .get(`/api/tenants`, {
-        headers: { Authorization: `Bearer ${context.user.accessJwt}` },
+const getDisplayTenants = (tenants, showHoused) =>
+  tenants.filter(tenant => showHoused || tenant.lease);
+
+export function Tenants() {
+  const userContext = useContext(UserContext)
+
+  const [allTenants, setAllTenants] = useState([]);
+  const [isSearchActive, setIsSearchActive] = useState([]);
+  const [showHoused, setShowHoused] = useState(false);
+  const [searchedTenants, setSearchedTenants] = useState([]);
+  const [displayTenants, setDisplayTenants] = useState([]);
+  // const [defaultSort, setDefaultSort] = useState(defaultSort)
+
+  useMountEffect(() => {
+    let allProperties;
+
+    axios.get(`/api/properties`, makeAuthHeaders(userContext))
+      .then(propertyResponse => {
+        const { data: { properties } } = propertyResponse;
+        allProperties = properties;
       })
+      .then(() =>
+        axios.get("/api/tenants", makeAuthHeaders(userContext))
+      )
       .then((response) => {
-        const tenants = response.data.tenants;
-        this.setState({ tenants });
+        const { data: { tenants } } = response;
+        const tenantRows = formatTenantData(tenants)
+        const tenantsWithProperties = addPropertyNames(tenantRows, allProperties)
+        const sortedTenants = sortTenantData(tenantsWithProperties)
+        setAllTenants(sortedTenants);
+        setSearchedTenants(sortedTenants);
+        setDisplayTenants(getDisplayTenants(sortedTenants, showHoused));
       })
       .catch((error) => {
-        Toast(error.message, "error");
-        console.log(error);
+        Toast(error.message, "error")
       });
-  };
+  })
 
-  render() {
-    return (
-      <UserContext.Consumer>
-        {session => {
-          this.context = session;
-          return (
-            <div className='main-container'>
-              <div>
-                <div className="section-header">
-                  <h2 className="page-title">Tenants</h2>
-                  <Link className="button is-primary is-rounded ml-4" to="/add/tenant">+ ADD NEW</Link>
-                </div>
-                <div className="search-section">
-                  <Search placeholderMessage="Search tenants by name, property, or JOIN staff" />
-                </div>
-                <div className="properties-list">
-                  <BootstrapTable
-                    keyField='id'
-                    data={this.state.tenants}
-                    columns={columns}
-                    selectRow={selectRow}
-                    bootstrap4={true}
-                    headerClasses="table-header"
-                    classes="table-responsive"
-                  />
-                </div>
-              </div>
-            </div>
-          );
-        }}
-      </UserContext.Consumer>
-    );
+  const handleToggleHoused = () => {
+    setShowHoused(!showHoused)
+    setDisplayTenants(getDisplayTenants(searchedTenants, !showHoused))
   }
-}
+
+  const handleDisableSearch = () => {
+    setSearchedTenants(allTenants);
+    setIsSearchActive(false);
+    setDisplayTenants(getDisplayTenants(allTenants, showHoused))
+  }
+
+  const handleSearchOutput = (output, isTrue) => {
+    setSearchedTenants(output);
+    setIsSearchActive(isTrue);
+    setDisplayTenants(getDisplayTenants(output, showHoused))
+  }
+
+  return (
+    <div className='main-container'>
+      <div className='tenants'>
+        <div className='section-header'>
+          <h2 className='page-title'>Tenants</h2>
+          <Link
+            className='button is-primary is-rounded ml-4'
+            to='/add/tenant'>+ ADD NEW</Link>
+        </div>
+        <div className='search-and-archive-container'>
+          <Search
+            input={allTenants}
+            outputLocation={searchedTenants}
+            isFilteredLocation={isSearchActive}
+            setIsFilteredStateFalse={handleDisableSearch}
+            setOutputState={handleSearchOutput}
+            placeholderMessage="Search tenants by name, property, or JOIN staff" />
+          <ShowHideSwitch
+            labelText="Unhoused:"
+            isShowState={showHoused}
+            handleToggleChange={handleToggleHoused}
+          />
+        </div>
+        <div className="tenants-list">
+          <BootstrapTable
+            key={`tables-of-tenants--${allTenants.length}`}
+            wrapperClasses='tenants-list-wrapper'
+            keyField='id'
+            data={displayTenants}
+            columns={columns}
+            defaultSorted={[
+              {
+                dataField: 'propertyName',
+                order: 'asc'
+              }]}
+            bootstrap4={true}
+            headerClasses='table-header'
+          />
+        </div>
+      </div>
+    </div>
+  )
+};

--- a/src/views/tenants/tenants.jsx
+++ b/src/views/tenants/tenants.jsx
@@ -101,8 +101,7 @@ export function Tenants() {
   }
 
   const handleToggleHoused = () => {
-    const newShowHoused = !showHoused;
-    setShowHoused(newShowHoused)
+    setShowHoused(!showHoused)
 
     if (isSearchActive) {
       setDisplayTenants(getDisplayTenants(searchedTenants, !showHoused, showArchived));
@@ -127,8 +126,7 @@ export function Tenants() {
   }
 
   const handleToggleArchived = () => {
-    const newShowArchived = !showArchived;
-    setShowArchived(newShowArchived);
+    setShowArchived(!showArchived);
 
     if (isSearchActive) {
       setDisplayTenants(getDisplayTenants(searchedTenants, showHoused, !showArchived));
@@ -138,8 +136,7 @@ export function Tenants() {
   }
 
   const toggleArchiveModal = () => {
-    const newShowArchiveModal = !showArchiveModal;
-    setShowArchiveModal(newShowArchiveModal)
+    setShowArchiveModal(!showArchiveModal)
   }
 
   const handleSelectRow = (tenant) => {

--- a/src/views/tenants/tenants.scss
+++ b/src/views/tenants/tenants.scss
@@ -1,0 +1,43 @@
+@import "../../scss/variables.scss";
+.tenants {
+  .section-header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .search-and-archive-container {
+    display: flex;
+    justify-content: space-between;
+    .search-section {
+      flex-grow: 1;
+    }
+  }
+
+  .bulk-actions-container {
+    margin-bottom: 10px;
+    button {
+      opacity: .25;
+      pointer-events: none;
+      transition: all 250ms ease;
+      &.is-active-button {
+        opacity: 1;
+        pointer-events: all;
+      }
+    }
+  }
+  .tenants-list{
+    margin-bottom: 20px;
+  }
+  .tenants-list-wrapper, table {
+    min-width: 100%;
+  }
+  .bell-icon{
+    color: $red;
+  }
+
+  .tenant-name {
+    margin-left: 7px;
+  }
+}
+

--- a/src/views/tenants/tenants.scss
+++ b/src/views/tenants/tenants.scss
@@ -39,5 +39,10 @@
   .tenant-name {
     margin-left: 7px;
   }
+  
+  ul.archive-properties-list {
+    list-style-position: inside;
+  }
+  
 }
 

--- a/src/views/tenants/tenantsFormStructure.js
+++ b/src/views/tenants/tenantsFormStructure.js
@@ -1,0 +1,82 @@
+import { Link } from "react-router-dom";
+import React from 'react'
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+import Tooltip from "../../components/ToolTip/ToolTip"
+import './tenants.scss'
+
+
+export const columns = [
+  {
+    dataField: "fullName",
+    formatter: (cell, row, rowIndex, formatExtraData) => {
+      return (
+        <div>
+          {(!row.fullName || row.staff.length === 0 || !row.phone) ?
+            <Tooltip
+              content="Tenant profile not complete"
+              direction="left"
+            >
+              <FontAwesomeIcon
+                className="tenants bell-icon"
+                icon={faExclamationTriangle}
+              />
+            </Tooltip>
+            : null
+          }
+          <Link
+            key={row.id}
+            to={`/manage/tenants/${row.id}`}
+            className="tenant-name"
+          >
+            {row.fullName}
+          </Link>
+        </div >
+      );
+    },
+    text: "Name",
+    sort: true,
+  },
+  {
+    dataField: "propertyName",
+    formatter: (cell, row, rowIndex, formatExtraData) => {
+      return (
+        <Link key={row.lease.id} to={`/manage/properties/${row.lease.propertyID}`}>
+          {row.propertyName}
+        </Link>
+      )
+    },
+    text: "Property Name",
+    sort: true,
+  },
+  {
+    dataField: `staff`,
+    formatter: (cell, row, rowIndex, formatExtraData) => {
+      return (
+        row.staff.map((staff, index) =>
+          <p key={`${staff}-${index}`} >
+            <Link key={row.id} to={`/staff`}>
+              {staff}
+            </Link>
+          </p >
+        ))
+    },
+    text: "JOIN Staff",
+    sort: true,
+  },
+  {
+    dataField: "phone",
+    text: "Phone",
+    sort: true,
+  },
+];
+
+
+export const selectRow = {
+  mode: "checkbox",
+  clickToSelect: true,
+  sort: true,
+  headerColumnStyle: () => {
+    return { width: "5%" };
+  },
+};


### PR DESCRIPTION
I apologize how long it took me to get this over the finish line.  I had a bunch of school stuff, and I'm just not unburying myself.

This PR addresses:
#437

After looking at 'properties', and how to handle the search bar functionality, I ended up rewriting the entire 'tenants' page. It is now a functional component, and I believe meets all of the requirements of the FIGMA, except pagination.

Issues addressed:
-Search bar throws no errors
-Search includes all visible properties
-Results are filtered in realtime, when bar is cleared data is rest to original unfiltered data
-JOIN staff names added to table, with links to JOIN staff page
-Search function include JOIN staff
-Show unhoused tenants toggle button added
-Tenants without assigned property are displayed first
-Bell icon added to tenants with missing data
-Default sorting was added


### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
- [x] There aren't any unnecessary commits or files changed (shouldn't touch the /stashed folder unless the issue requests it)

If you're having trouble meeting this criteria, feel free to reach out on Slack for help!