### PR TITLE
Make error handling consistent

### DIFF
--- a/src/views/addProperty/addProperty.jsx
+++ b/src/views/addProperty/addProperty.jsx
@@ -38,7 +38,7 @@ const formHandler = (data, context) => {
       Toast('Property Added!', 'success');
     })
     .catch(function(error) {
-      Toast(error, 'error');
+      Toast(error.message, 'error');
     });
 };
 
@@ -80,7 +80,7 @@ export class AddProperty extends Component {
         this.setState({ managerOptions, managerSelection: managerOptions });
       })
       .catch((error) => {
-        alert(error);
+        Toast(error.message, 'error');
         console.log(error);
       });
   };

--- a/src/views/joinStaff/joinStaff.jsx
+++ b/src/views/joinStaff/joinStaff.jsx
@@ -22,9 +22,9 @@ export const JoinStaff = () => {
         .then(res => {
           setStaff(...staff, res.data.users);
         })
-        .catch(err => {
-          Toast(err, "error");
-          console.log(err);
+        .catch(error => {
+          Toast(error.message, 'error');
+          console.log(error);
         });
     };
     Promise.all(URLs.map(url => fetchData(url)));

--- a/src/views/managers/managers.jsx
+++ b/src/views/managers/managers.jsx
@@ -118,7 +118,7 @@ const getManagers = (header, storeInState, updateLoading) => {
     })
     .catch((error) => {
       updateLoading(false);
-      Toast(error);
+      Toast(error.message, "error");
       console.log(error);
     });
 };


### PR DESCRIPTION
### What issue is this solving?
Closes issue #424 

After some discussion, it seems that the Toast error popups that appear if there is a server error serve the purpose intended in the open issue. They weren't consistently applied throughout the frontend (some pages showed no indication of error outside the console, one showed a JS alert instead of a Toast popup). This PR makes this type of error handling more consistent throughout the app.

### Please make sure you've attempted to meet the following coding standards
- [X] Code builds successfully
- [X] Code has been tested and does not produce errors
- [X] Code is readable and formatted
- [X] There isn't any unnecessary commented-out code
- [X] There aren't any unnecessary commits or files changed (shouldn't touch the /stashed folder unless the issue requests it)

If you're having trouble meeting this criteria, feel free to reach out on Slack for help!