### PR TITLE
Fix broken link in property card view

### DIFF
--- a/src/components/PropertyManagerCard/PropertyManagerCard.jsx
+++ b/src/components/PropertyManagerCard/PropertyManagerCard.jsx
@@ -13,7 +13,7 @@ function PropertyManagerCard({ manager, isEditing, removePropertyManager }) {
   return (
     <div className="property-manager-box box">
       <div>
-        <Link key={manager.id} to={`/manage/manager/${manager.id}`}>
+        <Link key={manager.id} to={`/manage/managers/${manager.id}`}>
           <p className="bold">{`${manager.firstName} ${manager.lastName}`}</p>
         </Link>
 

--- a/src/views/Property/PropertyView.jsx
+++ b/src/views/Property/PropertyView.jsx
@@ -137,7 +137,7 @@ const Property = () => {
           state: response.data.state,
           zipcode: response.data.zipcode,
           num_units: response.data.num_units,
-          propertyManager: response.data.propertyManager
+          propertyManagers: response.data.propertyManagers
         });
         setEditingStatus(false);
         Toast("Save successful!");
@@ -150,25 +150,25 @@ const Property = () => {
 
   const removePropertyManager = (id) => {
     let propertyManagerIDs = []
-    let propertyManager = []
+    let propertyManagers = []
 
-    for (let manager of property.propertyManager) {
+    for (let manager of property.propertyManagers) {
       if (manager.id !== id) {
         propertyManagerIDs.push(manager.id)
       }
       else {
-        propertyManager = property.propertyManager.filter(manager => manager.id !== id)
+        propertyManagers = property.propertyManagers.filter(manager => manager.id !== id)
       }
     }
-    setProperty({ ...property, propertyManager })
-    setInputValues({ ...property, propertyManager, propertyManagerIDs })
+    setProperty({ ...property, propertyManagers })
+    setInputValues({ ...property, propertyManagers, propertyManagerIDs })
   }
 
   const addPropertyManager = (id) => {
     property.propertyManagerIDs = [id];
 
-    if (property.propertyManager)
-      for (let manager of property.propertyManager) {
+    if (property.propertyManagers)
+      for (let manager of property.propertyManagers) {
         property.propertyManagerIDs.push(manager.id);
       }
 
@@ -179,8 +179,7 @@ const Property = () => {
       .then(response => {
         setProperty({
           ...property,
-          propertyManager: response.data.propertyManager,
-          propertyManagerName: response.data.propertyManagerName,
+          propertyManagers: response.data.propertyManagers,
         })
         setEditingStatus(false);
         Toast("Save successful!", "success");
@@ -352,16 +351,16 @@ const Property = () => {
             </div>
             {isEditing ?
               <ManagerSearchPanel
-                assignedPropertyManagers={property.propertyManager ?
-                  property.propertyManager.map(manager => { return manager.id })
+                assignedPropertyManagers={property.propertyManagers ?
+                  property.propertyManagers.map(manager => { return manager.id })
                   : []}
                 addPropertyManager={addPropertyManager}
               />
               :
               <></>}
             <div className="property-manager-section">
-              {property.propertyManager ?
-                property.propertyManager.map(manager => {
+              {property.propertyManagers ?
+                property.propertyManagers.map(manager => {
                   return <PropertyManagerCard
                     manager={manager}
                     key={manager.id}


### PR DESCRIPTION
# Description
- Updates to use new attribute names
  - Update `propertyManager` to `propertyManagers` because an array 
of propertyManagers is returned.
   - Removes `propertyManagerNames` doesn't look like this was being used
anywhere and the backend has removed this from the property serialization 
as that is a display responsibility not a serialization responsibility.
- Fixes broken link to property manager page
   - The link in the propertyManager card was incorrect.

### What issue is this solving?
There's no issue that I know of. These updates will work with backend PR codeforpdx/dwellinglybackend/pull/254

### Any helpful knowledge/context for the reviewer?
Is a `npm install` necessary? No
Any special requirements to test? No

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
- [x] There aren't any unnecessary commits or files changed (shouldn't touch the /stashed folder unless the issue requests it)
