### PR TITLE
Enable the frontend to run off a remote server

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-REACT_APP_PROXY=http://localhost:5000

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+## Uncomment one of the below lines depending on your needs
+# REACT_APP_PROXY=http://localhost:5000
+# REACT_APP_PROXY=https://dwellinglybackend.herokuapp.com

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ From Terminal:
 From terminal:
 
 - Navigate to app's directory: `cd dwellingly-app`
+- Copy `.env.example` to `.env` file. Look inside and adjust as needed.
+  - You have the option to run the backend API on the remote development server or locally.
 - Install: `npm install`
 - Launch: `npm start`
 - React will open a browser page for you and navigate to `localhost:3000`


### PR DESCRIPTION
**Description**
gitignoring the .env file. This file should be ignored as devs can have
different env vars, and they should be kept secret.

Created a `.env.example` file for people to copy to a `.env` file to get
them started.

Updated the Install docs to reflect this.

Added the option to run the backend off of a remote web server.

FYI: I renamed the `.env` file to `.env.example` so that the gitignore will take affect. This will cause everyones .env file to be deleted when this is pulled down. Which is what we want.
We will need to inform people that they will need to `cp .env.example .env` to get going again.