### PR TITLE
Set React Env Host for System tests

### DIFF
--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -15,6 +15,7 @@ env:
   SECRET_KEY: dwellingly
   TEST_DATABASE_URL: postgresql://localhost/dwellingly_test
   FLASK_ENV: testing
+  REACT_APP_PROXY: http://localhost:5000
 
 jobs:
   system_test:


### PR DESCRIPTION
whoops the PR that removed the env var from git was not updated with the
latest code. So the tests were not ran; otherwise they would've failed.

Set the required env var in for system tests.

