### PR TITLE
Remove race condition in updateProperty async functions

### DIFF
--- a/src/views/Property/PropertyView.jsx
+++ b/src/views/Property/PropertyView.jsx
@@ -100,7 +100,6 @@ const Property = () => {
   const handleConfirmButton = async () => {
 
     await updateProperty(inputValues);
-    getProperty();
     setConfirmChange(false);
   }
 


### PR DESCRIPTION
The `handleConfirmButton` awaits on the `updateProperty` function to
update the property, and then does an additional call to get the
property. The issue is that the await keyword doesn't really impact
anything here, because the `updateProperty` function is also an async
function. So what was happening was that sometimes the property would be
updated with stale information due to the `updateProperty` and
`getProperty` racing to fetch data and update the state.

Removed the `getProperty` call as it is not needed. The `updateProperty`
method already updates the state.

Fixes #677

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
- [x] There aren't any unnecessary commits or files changed (shouldn't touch the /stashed folder unless the issue requests it)

If you're having trouble meeting this criteria, feel free to reach out on Slack for help!