### PR TITLE
Revert "Show Property manager names and tenant count on properties grid"

### DIFF
--- a/src/views/properties/properties.jsx
+++ b/src/views/properties/properties.jsx
@@ -56,19 +56,13 @@ const makeAuthHeaders = ({ user }) => ({ headers: { 'Authorization': `Bearer ${u
 
 const getDisplayProperties = (properties, showArchived) => properties.filter(p => showArchived || !p.archived);
 
-const formatPropertyManagerNames = (propertyManagers) =>
-  propertyManagers.map(pm => `${pm.firstName} ${pm.lastName}`).join(', ');
-
-const formatTenantCount = (leases) =>
-  leases.map(l => l.occupants).reduce((sum, occupants) => sum + occupants);
-
 const formatPropertyData = (properties) => properties.map(p => ({
   id: p.id,
   archived: p.archived,
   name: p.name,
-  propertyManagerNames: p.propertyManagers && formatPropertyManagerNames(p.propertyManagers),
+  propertyManagerNames: p.propertyManagerName && p.propertyManagerName.join(", "),
   address: p.address,
-  totalTenants: p.leases && formatTenantCount(p.leases),
+  totalTenants: p.tenantIDs && p.tenantIDs.length,
   created_at: p.created_at
 }));
 


### PR DESCRIPTION
Reverts codeforpdx/dwellingly-app#674

This PR has broken development. Create a property and viewing the properties page results in the following error:
<img width="399" alt="Screen Shot 2021-09-06 at 11 06 01 AM" src="https://user-images.githubusercontent.com/19519317/132152692-0f585098-a1ac-484d-b0a2-bab23eb72db1.png">


Rather than creating a bug for this. I'm going to revert this change. Re-open the issue and ask for system tests and/or unit tests to be submitted with this PR to ensure no breaking changes.