### PR TITLE
Fix inviting a user (add property manager/staff)

### DIFF
--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Seed db
         run: |
           pipenv run flask db create
-          pipenv run flask db seed
+          pipenv run flask db minimal_seed
 
       - name: Start Server
         run: pipenv run flask run &

--- a/cypress.json
+++ b/cypress.json
@@ -1,1 +1,3 @@
-{}
+{
+  "baseUrl": "http://localhost:3000/"
+}

--- a/cypress/integration/user_invite.spec.js
+++ b/cypress/integration/user_invite.spec.js
@@ -1,0 +1,28 @@
+describe('Inviting', function () {
+  beforeEach(() => {
+    const email = 'user1@dwellingly.org'
+    const password = '1234'
+
+    cy.login(email, password)
+  })
+
+  it('creates a property manager user', function () {
+    cy.visit('/manage/managers')
+    cy.contains('+ ADD NEW').click()
+
+    cy.get('input[name="firstName"]').type('Elmer')
+    cy.get('input[name="lastName"]').type('Fudd')
+    cy.get('input[name="phone"]').type('503-555-5555')
+    cy.get('input[name="email"]').type('elmerfudd@looney.tunes')
+    cy.get('button').contains('SAVE').click()
+
+    cy.visit('/manage/managers')
+    cy.contains('Elmer Fudd').click()
+    cy.location('pathname').should('match', /^\/manage\/managers\/\d+$/)
+    cy.location('pathname').invoke('split', '/').its(3).as('elmerFuddID')
+
+    cy.get('@elmerFuddID').then(id => {
+      cy.deleteUser(id)
+    })
+  })
+})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,27 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+
+Cypress.Commands.add('login', (email, password) => {
+  cy.request({
+    method:'POST',
+    url:'api/login',
+    body: {
+      email,
+      password,
+    }
+  })
+    .its('body')
+    .then((body) => {
+      window.localStorage.setItem('dwellinglyAccess', body.access_token);
+      window.localStorage.setItem('dwellinglyRefresh', body.refresh_token);
+    })
+})
+
+Cypress.Commands.add('deleteUser', (id) => {
+  cy.request({
+    method: 'DELETE',
+    url: `api/user/${id}`,
+    headers: { 'Authorization' : `Bearer ${localStorage.dwellinglyAccess}` },
+  })
+})

--- a/src/Enums/UserType.js
+++ b/src/Enums/UserType.js
@@ -1,0 +1,7 @@
+const UserType = {
+    PROPERTY_MANAGER: "property_manager",
+    STAFF: "staff",
+    ADMIN: "admin"
+}
+
+export default UserType

--- a/src/views/addManager/addManager.jsx
+++ b/src/views/addManager/addManager.jsx
@@ -11,6 +11,7 @@ import Modal from '../../components/Modal';
 import Toast from '../../utils/toast';
 import useMountEffect from '../../utils/useMountEffect';
 import './addManager.scss';
+import UserType from '../../Enums/UserType';
 import RoleEnum from '../../Enums/RoleEnum';
 
 const validationSchema = Yup.object().shape({
@@ -76,9 +77,10 @@ export const AddManager = () => {
       ...data,
       password: 'changeAt1stLogin!',
       confirmPassword: 'changeAt1stLogin!',
+      type: UserType.PROPERTY_MANAGER,
       role: RoleEnum.PROPERTY_MANAGER,
     };
-    
+
     let properties = {
       propertyIDs: propertySelection.map(p => p.key)
     }
@@ -88,7 +90,7 @@ export const AddManager = () => {
       .then(response => {
         const managers = [] //backend is expecting an array to resolve assignment
         managers.push(response.data.id)
-        properties.propertyIDs.forEach(i => { 
+        properties.propertyIDs.forEach(i => {
           axios
           .put(`/api/properties/${i}`, {propertyManagerIDs: managers})  })
       })

--- a/src/views/addStaffMember/addStaffMember.jsx
+++ b/src/views/addStaffMember/addStaffMember.jsx
@@ -4,6 +4,7 @@ import { Form, Field, Formik } from "formik";
 import * as Yup from "yup";
 import * as axios from 'axios';
 import UserContext from "../../UserContext";
+import UserType from "../../Enums/UserType";
 import RoleEnum from "../../Enums/RoleEnum";
 import Toast from '../../utils/toast';
 import Button from "../../components/Button";
@@ -38,6 +39,7 @@ export const AddStaffMember = () => {
   const handleSave = (data) => {
     axios.post("/api/user/invite", {
       ...data,
+      type: data.makeAdmin ? UserType.ADMIN : UserType.STAFF,
       role: data.makeAdmin ? RoleEnum.ADMIN : RoleEnum.STAFF
     }, makeAuthHeaders(context))
       .then(function(response) {


### PR DESCRIPTION
This passes the type field along with the request which is necessary for
the user/invite endpoint. Eventually will be able to remove the role
field, but for now it is still required.

Fixes #678 

Not necessary, but a re-seeding of the db will ensure that there is a good data in the database for manually testing since this fixes an issue with bad data being populated to the db.