### PR TITLE
Label in progress as In Progress

### DIFF
--- a/src/views/dashboard/dashboard.jsx
+++ b/src/views/dashboard/dashboard.jsx
@@ -62,11 +62,11 @@ export const Dashboard = (props) => {
         [
           {
             "stat": inProgressTickets.allInProgress.stat,
-            "desc": "New"
+            "desc": "In Progress"
           },
           {
             "stat": inProgressTickets.inProgress1Week.stat,
-            "desc": "Unseen for > 24 hours"
+            "desc": "In progress for > 1 week"
           },
         ]];
 


### PR DESCRIPTION
### What issue is this solving?
There's no open issue that I know of. Fixes label on the dashboard.

<img width="414" alt="Screen Shot 2021-10-24 at 6 41 21 PM" src="https://user-images.githubusercontent.com/19519317/138588665-45cbd615-2246-44be-b797-93c98e2e79ae.png">

