### PR TITLE
Create tests and refactor add property manager view

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -18,6 +18,24 @@ class InvitationsController < Devise::InvitationsController
   end
 
   def invite_params
-    params.require(:invitation).permit(:firstName, :lastName, :phone, :email, :type, :role)
+    params.require(:invitation).permit(shared_params + resource_params)
+  end
+
+  def shared_params
+    [:firstName, :lastName, :phone, :email, :type, :role]
+  end
+
+  def resource_params
+    case resource_class.new
+    when PropertyManager
+      [{ property_ids: [] }]
+    else
+      []
+    end
+  end
+
+  # Overwrite Devise::Invitations resource_class method
+  def resource_class
+    params.dig(:invitation, :type).constantize
   end
 end

--- a/cypress/integration/property_managers/add_property_manager.spec.js
+++ b/cypress/integration/property_managers/add_property_manager.spec.js
@@ -1,0 +1,43 @@
+describe('Add Property Manager', function () {
+  beforeEach(() => {
+    const admin = 'admin@dwellingly.org'
+
+    cy.app('clean')
+    cy.appScenario('basic')
+    cy.login(admin)
+  })
+
+  it('creates a property manager', function () {
+    cy.visit('manage/managers')
+    cy.contains('+ ADD NEW').click()
+    cy.fillInPropertyManagerForm()
+    cy.get('button').contains('SAVE').click()
+    cy.wait(500)
+
+    cy.visit('manage/managers')
+    cy.wait(500)
+    cy.contains('pm@thepowells.lake').should('exist')
+    cy.contains('Franky Property Manager').click()
+    cy.location('pathname').should('match', /^\/manage\/managers\/\d+$/)
+  })
+
+  it('creates a property manager with an assigned proeprty', function () {
+    cy.visit('add/manager')
+    cy.wait(500)
+
+    cy.contains('Create New Property').click()
+    cy.fillInPropertyForm()
+    cy.get('form.add-property__form-container').contains('SAVE').click()
+    cy.get('form.add-property__form-container').should('not.exist')
+    cy.contains('The Tenants').should('exist')
+
+    cy.fillInPropertyManagerForm()
+    cy.get('button').contains('SAVE').click()
+    cy.wait(500)
+
+    cy.visit('/manage/properties')
+    cy.wait(500)
+    cy.contains('The Tenants').should('exist')
+    cy.contains('Franky Property Manager').should('exist')
+  })
+})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -121,3 +121,10 @@ Cypress.Commands.add('fillInTenantForm', () => {
   cy.get('input[name="lastName"]').type('Bob')
   cy.get('input[name="phone"]').type('555-555-5555')
 })
+
+Cypress.Commands.add('fillInPropertyManagerForm', () => {
+  cy.get('input[name="firstName"]').type('Franky')
+  cy.get('input[name="lastName"]').type('Property Manager')
+  cy.get('input[name="phone"]').type('555-555-5555')
+  cy.get('input[name="email"]').type('pm@thepowells.lake')
+})


### PR DESCRIPTION
### What issue is this solving?
 - Create tests and refactor add property manager view
     - Fixes #744 Create system tests for adding a property manager.
     - Fixes #747 Assign properties to a new property manager without removing other assignments for the property.
     - Fixes #752 Remove hard-coded password
     

I'm not so sure I like the second commit vvv. 
- Retrieve properties only if users intends to search
   - Retrieves the properties prior to the first search instead of on page load.
   - This decreases the amount of data and requests that are made to load the initial page.

### Any helpful knowledge/context for the reviewer?
Is a `npm install` necessary? **YES**
Any special requirements to test? NO

### Please make sure you've attempted to meet the following coding standards
- [x] Code builds successfully
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
- [x] There aren't any unnecessary commits or files changed