### PR TITLE
Turn off video recording by default for cypress tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -4,5 +4,6 @@
   "retries": {
     "runMode": 2,
     "openMode": 0
-  }
+  },
+  "video": false
 }


### PR DESCRIPTION
Turns video recording off by default when running cypress tests.