### PR TITLE
Setup `bin/dev` file to start server and compile js

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server -p 3000
+webpack: bin/webpack-dev-server

--- a/README.md
+++ b/README.md
@@ -54,9 +54,11 @@ From terminal:
 - run `cp config/application.yml.example config/application.yml`
 - If using sqlite3 then uncomment sqlite3 in the `config/application.yml` file.
 - Create, load, and seed the database with: `bin/rails db:setup`
-- Start server with: `bin/rails s`
-- For now its necessary to also start a js server with: `./bin/webpack-dev-server`
-  - This will precompile javascript and reload the browser when there are javascript changes
+- Start the servers
+  - Start the Rails server with: `bin/rails s`
+  - Start the weback server with: `./bin/webpack-dev-server`
+    - This will precompile javascript and reload the browser when there are javascript changes
+  - Alternatively: You can use `bin/dev` to start both servers. (May not work with Windows)
 
 ## About Us
 * [Code for PDX](https://www.codeforpdx.org/) - [Meetup Info](https://www.meetup.com/Code-for-PDX/)

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if ! command -v foreman &> /dev/null
+then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+foreman start -f Procfile.dev


### PR DESCRIPTION
## Description

Sets up a `bin/dev` file to start the rails server and any other required systems needed for development.

As of now this starts the Rails server and the webpack server so that javascript changes are automatically compiled and reloaded on change.

@Chris-Boe and @kgottfri can you pull this down and approve the PR if it works for you?