### PR TITLE
Update `lastActive` when user signs in

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,6 +16,7 @@ class SessionsController < Devise::SessionsController
 
     if resource.valid_password?(params[:password])
       sign_in :user, resource
+      resource.update!(lastActive: Time.current)
       return render json: resource.to_json
     end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,7 +16,7 @@ class SessionsController < Devise::SessionsController
 
     if resource.valid_password?(params[:password])
       sign_in :user, resource
-      resource.update!(lastActive: Time.current)
+      resource.update_column(:lastActive, Time.current) # rubocop:disable Rails/SkipsModelValidations
       return render json: resource.to_json
     end
 

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe "/api/resource", type: :request do
+  describe "POST /sign_in" do
+    it "updates the user's lastActive timestamp on sign in" do
+      property_manager = create(:property_manager)
+      expect(property_manager.lastActive).to be_nil
+
+      post user_session_url, params: { email: property_manager.email, password: property_manager.password }
+      expect(JSON.parse(response.body)["lastActive"]).not_to be_nil
+    end
+  end
+end


### PR DESCRIPTION
### What issue is this solving?
closes #829 

The front end was rendering the "Last Usage" column based on the user's `lastActive` status, but this field in the database was never getting updated. Since we're not using devise trackable (which would automatically update `last_sign_in_at`, `current_sign_in_at`, etc.) we need to update this value ourselves.

Note, this saves the datetime in the db in UTC time.  I don't think we alter that for the front-end, so it may look off by a day if checked at certain times.

Screenshot
![image](https://user-images.githubusercontent.com/44326005/180623491-8159239b-be49-4603-849e-f0fd41a8e87d.png)


### Any helpful knowledge/context for the reviewer?
Is a `yarn install` necessary? ❌ 
Any special requirements to test? 
- Sign up a new user
- Sign in as admin and approve them as Property Manager
- See that they are still marked as Pending
- Sign in as the new user
- Sign back in as admin to see "Last Usage" column updated.

### Please make sure you've attempted to meet the following coding standards
- [x] There aren't any unnecessary commits or files changed
- [x] Code has been tested and does not produce errors
- [x] There isn't any unnecessary commented-out code

If you're having trouble meeting this criteria, feel free to reach out on Slack for help!
