### PR TITLE
use math.div for sass division

### DIFF
--- a/app/javascript/components/src/views/components/TicketModal/components/Card/styles/index.scss
+++ b/app/javascript/components/src/views/components/TicketModal/components/Card/styles/index.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 @import "../../../../../../scss/variables.scss";
 
 
@@ -15,7 +16,7 @@ $width__wrapper: 800px;
 
 /* F U N C T I O N S */
 @function emify($target, $context) {
-  @return ($target/$context) * 1em;
+  @return math.div($target, $context) * 1em;
 }
 /* end functions */
 
@@ -384,7 +385,7 @@ button .card {
         display: block;
         height: $ticket__cutout-size--height;
         width: $ticket__cutout-size--width;
-        
+
         overflow: hidden;
         position: absolute;
 


### PR DESCRIPTION
### What issue is this solving?
No existing issue to close.

Updates `emify` sass function to use `math.div` instead of `/` for division.
This gets rid of the following deprecation warning when starting up the app:

![image](https://user-images.githubusercontent.com/44326005/180624764-293566ad-493e-4e4f-805c-480729272eb8.png)

If we upgraded the version of sass we use, it could be changed to use the [calculations syntax](https://sass-lang.com/documentation/values/calculations) `calc($target / $context)` and we wouldn't need to import the math module, but I'm not sure if we can safely upgrade sass or if `sass-rails` depends on the current version.

### Any helpful knowledge/context for the reviewer?
Is a `yarn install` necessary? ❌ 
Any special requirements to test? ❌ 

### Please make sure you've attempted to meet the following coding standards
- [x] There aren't any unnecessary commits or files changed
- [x] Code has been tested and does not produce errors
- [x] There isn't any unnecessary commented-out code

If you're having trouble meeting this criteria, feel free to reach out on Slack for help!
